### PR TITLE
Petrel: resetRequestedEvent — lexicon + Swift/Kotlin regen

### DIFF
--- a/Sources/Petrel/Generated/Core/Types/ATProtocolValueContainer.swift
+++ b/Sources/Petrel/Generated/Core/Types/ATProtocolValueContainer.swift
@@ -2411,6 +2411,16 @@ public indirect enum ATProtocolValueContainer: ATProtocolCodable, ATProtocolValu
                 }
             }
             
+            decoders["blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent"] = { decoder in
+                do {
+                    let decodedObject = try BlueCatbirdMlsChatSubscribeEvents.ResetRequestedEvent(from: decoder)
+                    return .knownType(decodedObject)
+                } catch {
+                    LogManager.logDebug("Error decoding BlueCatbirdMlsChatSubscribeEvents.ResetRequestedEvent: \(error)")
+                    return .decodeError("Error decoding BlueCatbirdMlsChatSubscribeEvents.ResetRequestedEvent: \(error)")
+                }
+            }
+            
             decoders["blue.catbird.mlsDS.getFederationPeers#peerRecord"] = { decoder in
                 do {
                     let decodedObject = try BlueCatbirdMlsDSGetFederationPeers.PeerRecord(from: decoder)

--- a/Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatSubscribeEvents.swift
+++ b/Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatSubscribeEvents.swift
@@ -1351,6 +1351,208 @@ public struct CircuitBreakerTrippedEvent: ATProtocolCodable, ATProtocolValue {
             case resetCount
             case trippedAt
         }
+    }
+        
+public struct ResetRequestedEvent: ATProtocolCodable, ATProtocolValue {
+            public static let typeIdentifier = "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent"
+            public let cursor: String
+            public let convoId: String
+            public let cryptoSessionId: String
+            public let generation: Int
+            public let trigger: String
+            public let requestEventId: String
+            public let expectedNewMlsGroupId: String?
+            public let reason: String?
+            public let requestedAt: ATProtocolDate?
+
+        public init(
+            cursor: String, convoId: String, cryptoSessionId: String, generation: Int, trigger: String, requestEventId: String, expectedNewMlsGroupId: String?, reason: String?, requestedAt: ATProtocolDate?
+        ) {
+            self.cursor = cursor
+            self.convoId = convoId
+            self.cryptoSessionId = cryptoSessionId
+            self.generation = generation
+            self.trigger = trigger
+            self.requestEventId = requestEventId
+            self.expectedNewMlsGroupId = expectedNewMlsGroupId
+            self.reason = reason
+            self.requestedAt = requestedAt
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            do {
+                self.cursor = try container.decode(String.self, forKey: .cursor)
+            } catch {
+                LogManager.logError("Decoding error for required property 'cursor': \(error)")
+                throw error
+            }
+            do {
+                self.convoId = try container.decode(String.self, forKey: .convoId)
+            } catch {
+                LogManager.logError("Decoding error for required property 'convoId': \(error)")
+                throw error
+            }
+            do {
+                self.cryptoSessionId = try container.decode(String.self, forKey: .cryptoSessionId)
+            } catch {
+                LogManager.logError("Decoding error for required property 'cryptoSessionId': \(error)")
+                throw error
+            }
+            do {
+                self.generation = try container.decode(Int.self, forKey: .generation)
+            } catch {
+                LogManager.logError("Decoding error for required property 'generation': \(error)")
+                throw error
+            }
+            do {
+                self.trigger = try container.decode(String.self, forKey: .trigger)
+            } catch {
+                LogManager.logError("Decoding error for required property 'trigger': \(error)")
+                throw error
+            }
+            do {
+                self.requestEventId = try container.decode(String.self, forKey: .requestEventId)
+            } catch {
+                LogManager.logError("Decoding error for required property 'requestEventId': \(error)")
+                throw error
+            }
+            do {
+                self.expectedNewMlsGroupId = try container.decodeIfPresent(String.self, forKey: .expectedNewMlsGroupId)
+            } catch {
+                LogManager.logDebug("Decoding error for optional property 'expectedNewMlsGroupId': \(error)")
+                throw error
+            }
+            do {
+                self.reason = try container.decodeIfPresent(String.self, forKey: .reason)
+            } catch {
+                LogManager.logDebug("Decoding error for optional property 'reason': \(error)")
+                throw error
+            }
+            do {
+                self.requestedAt = try container.decodeIfPresent(ATProtocolDate.self, forKey: .requestedAt)
+            } catch {
+                LogManager.logDebug("Decoding error for optional property 'requestedAt': \(error)")
+                throw error
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(Self.typeIdentifier, forKey: .typeIdentifier)
+            try container.encode(cursor, forKey: .cursor)
+            try container.encode(convoId, forKey: .convoId)
+            try container.encode(cryptoSessionId, forKey: .cryptoSessionId)
+            try container.encode(generation, forKey: .generation)
+            try container.encode(trigger, forKey: .trigger)
+            try container.encode(requestEventId, forKey: .requestEventId)
+            try container.encodeIfPresent(expectedNewMlsGroupId, forKey: .expectedNewMlsGroupId)
+            try container.encodeIfPresent(reason, forKey: .reason)
+            try container.encodeIfPresent(requestedAt, forKey: .requestedAt)
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(cursor)
+            hasher.combine(convoId)
+            hasher.combine(cryptoSessionId)
+            hasher.combine(generation)
+            hasher.combine(trigger)
+            hasher.combine(requestEventId)
+            if let value = expectedNewMlsGroupId {
+                hasher.combine(value)
+            } else {
+                hasher.combine(nil as Int?)
+            }
+            if let value = reason {
+                hasher.combine(value)
+            } else {
+                hasher.combine(nil as Int?)
+            }
+            if let value = requestedAt {
+                hasher.combine(value)
+            } else {
+                hasher.combine(nil as Int?)
+            }
+        }
+
+        public func isEqual(to other: any ATProtocolValue) -> Bool {
+            guard let other = other as? Self else { return false }
+            if cursor != other.cursor {
+                return false
+            }
+            if convoId != other.convoId {
+                return false
+            }
+            if cryptoSessionId != other.cryptoSessionId {
+                return false
+            }
+            if generation != other.generation {
+                return false
+            }
+            if trigger != other.trigger {
+                return false
+            }
+            if requestEventId != other.requestEventId {
+                return false
+            }
+            if expectedNewMlsGroupId != other.expectedNewMlsGroupId {
+                return false
+            }
+            if reason != other.reason {
+                return false
+            }
+            if requestedAt != other.requestedAt {
+                return false
+            }
+            return true
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            return lhs.isEqual(to: rhs)
+        }
+
+        public func toCBORValue() throws -> Any {
+            var map = OrderedCBORMap()
+            map = map.adding(key: "$type", value: Self.typeIdentifier)
+            let cursorValue = try cursor.toCBORValue()
+            map = map.adding(key: "cursor", value: cursorValue)
+            let convoIdValue = try convoId.toCBORValue()
+            map = map.adding(key: "convoId", value: convoIdValue)
+            let cryptoSessionIdValue = try cryptoSessionId.toCBORValue()
+            map = map.adding(key: "cryptoSessionId", value: cryptoSessionIdValue)
+            let generationValue = try generation.toCBORValue()
+            map = map.adding(key: "generation", value: generationValue)
+            let triggerValue = try trigger.toCBORValue()
+            map = map.adding(key: "trigger", value: triggerValue)
+            let requestEventIdValue = try requestEventId.toCBORValue()
+            map = map.adding(key: "requestEventId", value: requestEventIdValue)
+            if let value = expectedNewMlsGroupId {
+                let expectedNewMlsGroupIdValue = try value.toCBORValue()
+                map = map.adding(key: "expectedNewMlsGroupId", value: expectedNewMlsGroupIdValue)
+            }
+            if let value = reason {
+                let reasonValue = try value.toCBORValue()
+                map = map.adding(key: "reason", value: reasonValue)
+            }
+            if let value = requestedAt {
+                let requestedAtValue = try value.toCBORValue()
+                map = map.adding(key: "requestedAt", value: requestedAtValue)
+            }
+            return map
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case typeIdentifier = "$type"
+            case cursor
+            case convoId
+            case cryptoSessionId
+            case generation
+            case trigger
+            case requestEventId
+            case expectedNewMlsGroupId
+            case reason
+            case requestedAt
+        }
     }    
 public struct Parameters: Parametrizable {
         public let ticket: String?
@@ -1388,6 +1590,8 @@ public enum Message: Codable, Sendable {
     case readditionRequestedEvent(ReadditionRequestedEvent)
 
     case circuitBreakerTrippedEvent(CircuitBreakerTrippedEvent)
+
+    case resetRequestedEvent(ResetRequestedEvent)
 
 
     enum CodingKeys: String, CodingKey {
@@ -1444,6 +1648,10 @@ public enum Message: Codable, Sendable {
             let value = try CircuitBreakerTrippedEvent(from: decoder)
             self = .circuitBreakerTrippedEvent(value)
 
+        case "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent":
+            let value = try ResetRequestedEvent(from: decoder)
+            self = .resetRequestedEvent(value)
+
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
@@ -1487,6 +1695,9 @@ public enum Message: Codable, Sendable {
             try value.encode(to: encoder)
 
         case .circuitBreakerTrippedEvent(let value):
+            try value.encode(to: encoder)
+
+        case .resetRequestedEvent(let value):
             try value.encode(to: encoder)
 
         }

--- a/petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatSubscribeEvents.kt
+++ b/petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatSubscribeEvents.kt
@@ -51,6 +51,9 @@ sealed interface BlueCatbirdMlsChatSubscribeEventsMessageUnion {
     data class CircuitBreakerTrippedEvent(val value: com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsCircuitBreakerTrippedEvent) : BlueCatbirdMlsChatSubscribeEventsMessageUnion
 
     @Serializable
+    data class ResetRequestedEvent(val value: com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent) : BlueCatbirdMlsChatSubscribeEventsMessageUnion
+
+    @Serializable
     data class Unexpected(val value: JsonElement) : BlueCatbirdMlsChatSubscribeEventsMessageUnion
 }
 
@@ -127,6 +130,12 @@ object BlueCatbirdMlsChatSubscribeEventsMessageUnionSerializer : kotlinx.seriali
                     it["\$type"] = kotlinx.serialization.json.JsonPrimitive("blue.catbird.mlsChat.subscribeEvents#circuitBreakerTrippedEvent")
                 })
             }
+            is BlueCatbirdMlsChatSubscribeEventsMessageUnion.ResetRequestedEvent -> {
+                val obj = jsonEncoder.json.encodeToJsonElement(com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent.serializer(), value.value)
+                kotlinx.serialization.json.JsonObject(obj.jsonObject.toMutableMap().also {
+                    it["\$type"] = kotlinx.serialization.json.JsonPrimitive("blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent")
+                })
+            }
             is BlueCatbirdMlsChatSubscribeEventsMessageUnion.Unexpected -> value.value
             // Synthetic variants (e.g. <Union>Error / <Union>Unexpected added by
             // subscription codegen) are runtime-only sentinels; JSON round-trip
@@ -178,6 +187,9 @@ object BlueCatbirdMlsChatSubscribeEventsMessageUnionSerializer : kotlinx.seriali
             )
             "blue.catbird.mlsChat.subscribeEvents#circuitBreakerTrippedEvent" -> BlueCatbirdMlsChatSubscribeEventsMessageUnion.CircuitBreakerTrippedEvent(
                 jsonDecoder.json.decodeFromJsonElement(com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsCircuitBreakerTrippedEvent.serializer(), element)
+            )
+            "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent" -> BlueCatbirdMlsChatSubscribeEventsMessageUnion.ResetRequestedEvent(
+                jsonDecoder.json.decodeFromJsonElement(com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent.serializer(), element)
             )
             else -> BlueCatbirdMlsChatSubscribeEventsMessageUnion.Unexpected(element)
         }
@@ -357,6 +369,26 @@ object BlueCatbirdMlsChatSubscribeEventsMessageUnionSerializer : kotlinx.seriali
         }
     }
 
+    /**
+     * Phase 2.5: an indirect trigger (quorum vote, system sweep, inline 409/404) has requested a crypto session reset. Active members are invited to respond by submitting new MLS group material via bootstrapResetGroup or commitGroupChange. First commit wins via UNIQUE (conversation_id, generation) tie-break. The previous groupResetEvent is also emitted for backward compatibility during Stage 1.
+     */
+    @Serializable
+    data class BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent(
+/** Resume cursor for this event position */        @SerialName("cursor")
+        val cursor: String,/** Conversation identifier */        @SerialName("convoId")
+        val convoId: String,/** Server-side opaque id of the crypto_session whose reset was requested (the prior session, now in state='reset_requested') */        @SerialName("cryptoSessionId")
+        val cryptoSessionId: String,/** Generation number of the prior session — clients should activate at generation+1 */        @SerialName("generation")
+        val generation: Int,/** Which subsystem produced the reset request */        @SerialName("trigger")
+        val trigger: String,/** Server-side opaque id of the crypto_session_reset_requested delivery_event for correlation */        @SerialName("requestEventId")
+        val requestEventId: String,/** If non-null, only this mls_group_id may activate. Phase 2.5 indirect triggers always emit null here; admin/bootstrap direct flows always provide a value. */        @SerialName("expectedNewMlsGroupId")
+        val expectedNewMlsGroupId: String? = null,/** Human-readable reason for the reset */        @SerialName("reason")
+        val reason: String? = null,/** When the reset was requested (RFC3339) */        @SerialName("requestedAt")
+        val requestedAt: ATProtocolDate? = null    ) {
+        companion object {
+            const val TYPE_IDENTIFIER = "#blueCatbirdMlsChatSubscribeEventsResetRequestedEvent"
+        }
+    }
+
 @Serializable
     data class BlueCatbirdMlsChatSubscribeEventsParameters(
 // JWT ticket from getSubscriptionTicket for authentication        @SerialName("ticket")
@@ -470,6 +502,12 @@ hostOverride: String? = null,
                         "#circuitBreakerTrippedEvent" -> BlueCatbirdMlsChatSubscribeEventsMessageUnion.CircuitBreakerTrippedEvent(
                             json.decodeFromJsonElement(
                                 com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsCircuitBreakerTrippedEvent.serializer(),
+                                frame.payload
+                            )
+                        )
+                        "#resetRequestedEvent" -> BlueCatbirdMlsChatSubscribeEventsMessageUnion.ResetRequestedEvent(
+                            json.decodeFromJsonElement(
+                                com.atproto.generated.BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent.serializer(),
                                 frame.payload
                             )
                         )


### PR DESCRIPTION
## Summary

Adds the `resetRequestedEvent` variant to `blue.catbird.mlsChat.subscribeEvents` and regenerates Swift + Kotlin types.

This is the client SDK side of mls-ds Phase 2.5 Stage 1: the server emits this event when an indirect trigger (quorum vote, system sweep, inline `409`/`404` recovery) requests a crypto-session reset. Active members respond by submitting new MLS material via `bootstrapResetGroup` or `commitGroupChange`; first commit wins via the `UNIQUE (conversation_id, generation)` tie-break. The legacy `groupResetEvent` is still emitted for backward compatibility during Stage 1.

Plan: `~/.claude/plans/phase-2-5-indirect-funneling.md` §3 (API contract changes).

## Field schema

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `cursor` | string | yes | Resume cursor for this event position |
| `convoId` | string | yes | Conversation identifier |
| `cryptoSessionId` | string | yes | Server-side opaque id of the prior `crypto_session` (now in state `reset_requested`) |
| `generation` | integer | yes | Generation number of the prior session — clients activate at `generation + 1` |
| `trigger` | string | yes | One of `quorum_vote`, `system_sweep`, `inline_commit_409`, `inline_groupinfo_404` |
| `requestEventId` | string | yes | Server-side opaque id of the `crypto_session_reset_requested` delivery_event for correlation |
| `expectedNewMlsGroupId` | string | no | If non-null, only this `mls_group_id` may activate. Indirect triggers emit null; admin/bootstrap direct flows provide a value. |
| `reason` | string | no | Human-readable reason for the reset |
| `requestedAt` | datetime | no | When the reset was requested (RFC3339) |

## Changes

- `Generator/lexicons/blue/catbird/mlsChat/blue.catbird.mlsChat.subscribeEvents.json`: add the `resetRequestedEvent` variant + `#resetRequestedEvent` ref in the message union (commit `76f6f19f`, already on `main`).
- `Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatSubscribeEvents.swift`: generated `ResetRequestedEvent` struct (`+208 lines`).
- `Sources/Petrel/Generated/Core/Types/ATProtocolValueContainer.swift`: registered decoder for `blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent` (`+10 lines`).
- `petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatSubscribeEvents.kt`: generated `BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent` data class + serializer wiring (`+38 lines`).

Total regen diff: 3 files, +259 lines (no removals). All output produced by `python3 run.py Generator/lexicons Sources/Petrel/Generated --language both` and was reproducible.

## Cross-references

- catbird-atproto regen (Rust types via Jacquard): https://github.com/joshlacal/catbird-atproto/pull/1
- mls-ds lexicon source change: https://github.com/joshlacal/mls-ds/pull/4

This is part of mls-ds Phase 2.5 Stage 1. The Stage 1 server work lives on `mls-ds` branch `feature/phase-2-5-stage-1` and is owned by a separate agent. Clients consume these new types in Wave 2.

## Test plan

- [ ] `swift build` (Petrel) succeeds with no warnings on the new types
- [ ] Catbird/CatbirdMLSCore consumer call sites compile after pulling the new Petrel
- [ ] Android/petrel-kotlin compiles with the new Kotlin data class
- [ ] Manual round-trip: encode/decode a `resetRequestedEvent` JSON envelope through `ATProtocolValueContainer` (Swift) and `BlueCatbirdMlsChatSubscribeEventsMessageUnionSerializer` (Kotlin)
