### PR TITLE
Petrel-Kotlin: add MlsChatResetRequestedEvent to hand-written WS parser

### DIFF
--- a/petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt
+++ b/petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt
@@ -15,6 +15,8 @@ import io.ktor.websocket.readBytes
 import io.ktor.websocket.readText
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import java.util.logging.Logger
 
@@ -140,6 +142,42 @@ data class MlsChatGroupResetEvent(
     val resetBy: String? = null,
     val cipherSuite: String? = null,
     val reason: String? = null
+) : MlsChatRealtimeEvent
+
+/**
+ * Phase 2.5: an indirect trigger (quorum vote, system sweep, inline 409/404)
+ * has requested a crypto-session reset. Active members are invited to respond
+ * by submitting fresh MLS group material via `bootstrapResetGroup` /
+ * `commitGroupChange`; first commit wins via UNIQUE (conversation_id, generation).
+ *
+ * Mirrors `BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent` from the
+ * generated lexicon code (the schema source of truth) and the server-side
+ * `StreamEvent::ResetRequestedEvent` wire emission in
+ * `mls-ds/server/src/realtime/sse.rs`.
+ *
+ * Note: `requestedAt` is exposed as a raw `String?` (RFC3339) to stay
+ * consistent with the other hand-written bridge types in this file, which
+ * use plain Kotlin types instead of codegen's `ATProtocolDate`. The server
+ * always emits this field; we tolerate absence to match the lexicon's
+ * nullable definition.
+ *
+ * Note: this class is `@Serializable` so that [realtimeJson]'s
+ * `decodeFromJsonElement` can construct it. The other hand-written bridge
+ * classes in this file are NOT annotated, which leaves them latently
+ * unable to decode at runtime — pre-existing issue, out of scope for this
+ * PR (see PR description).
+ */
+@Serializable
+data class MlsChatResetRequestedEvent(
+    @SerialName("cursor") val cursor: String,
+    @SerialName("convoId") val convoId: String,
+    @SerialName("cryptoSessionId") val cryptoSessionId: String,
+    @SerialName("generation") val generation: Int,
+    @SerialName("trigger") val trigger: String,
+    @SerialName("requestEventId") val requestEventId: String,
+    @SerialName("expectedNewMlsGroupId") val expectedNewMlsGroupId: String? = null,
+    @SerialName("reason") val reason: String? = null,
+    @SerialName("requestedAt") val requestedAt: String? = null
 ) : MlsChatRealtimeEvent
 
 // MARK: - subscribeEvents extension function
@@ -311,6 +349,10 @@ internal fun parseRealtimeEvent(json: JsonObject): MlsChatRealtimeEvent? {
             eventType.contains("groupResetEvent", ignoreCase = true) ||
             eventType.contains("#groupReset") -> {
                 realtimeJson.decodeFromJsonElement<MlsChatGroupResetEvent>(payload)
+            }
+            eventType.contains("resetRequestedEvent", ignoreCase = true) ||
+            eventType.contains("#resetRequestedEvent") -> {
+                realtimeJson.decodeFromJsonElement<MlsChatResetRequestedEvent>(payload)
             }
             else -> null
         }

--- a/petrel-kotlin/src/test/kotlin/com/atproto/client/MlsChatRealtimeTypesTest.kt
+++ b/petrel-kotlin/src/test/kotlin/com/atproto/client/MlsChatRealtimeTypesTest.kt
@@ -1,0 +1,146 @@
+package com.atproto.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the hand-written WebSocket realtime parser in
+ * [MlsChatRealtimeTypes]. Specifically guards the Phase 2.5
+ * `#resetRequestedEvent` dispatch added to support
+ * [MlsChatResetRequestedEvent].
+ *
+ * The bridge classes' shape is the source of truth here, but field names
+ * MUST match `BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent` in
+ * the generated codegen, which in turn matches the server-side wire
+ * emission in `mls-ds/server/src/realtime/sse.rs`.
+ */
+class MlsChatRealtimeTypesTest {
+
+    @Test
+    fun resetRequestedEventFullPayloadParses() {
+        val frame = """
+            {
+              "t": "event",
+              "seq": 42,
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent",
+                "cursor": "100",
+                "convoId": "convo-abc",
+                "cryptoSessionId": "csess-123",
+                "generation": 7,
+                "trigger": "quorum",
+                "requestEventId": "evt-9001",
+                "expectedNewMlsGroupId": "grp-future-xyz",
+                "reason": "epoch spiral",
+                "requestedAt": "2026-04-28T10:11:12Z"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        assertEquals(42L, msg.seq)
+
+        val payload = msg.payload
+        assertIs<MlsChatResetRequestedEvent>(payload)
+        assertEquals("100", payload.cursor)
+        assertEquals("convo-abc", payload.convoId)
+        assertEquals("csess-123", payload.cryptoSessionId)
+        assertEquals(7, payload.generation)
+        assertEquals("quorum", payload.trigger)
+        assertEquals("evt-9001", payload.requestEventId)
+        assertEquals("grp-future-xyz", payload.expectedNewMlsGroupId)
+        assertEquals("epoch spiral", payload.reason)
+        assertEquals("2026-04-28T10:11:12Z", payload.requestedAt)
+    }
+
+    @Test
+    fun resetRequestedEventMinimalPayloadParses() {
+        // Lexicon allows expectedNewMlsGroupId / reason / requestedAt to be omitted.
+        // Verify the parser tolerates absence and leaves the optionals null.
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent",
+                "cursor": "200",
+                "convoId": "convo-min",
+                "cryptoSessionId": "csess-min",
+                "generation": 1,
+                "trigger": "system_sweep",
+                "requestEventId": "evt-min"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatResetRequestedEvent>(payload)
+        assertEquals("convo-min", payload.convoId)
+        assertEquals(1, payload.generation)
+        assertEquals("system_sweep", payload.trigger)
+        assertNull(payload.expectedNewMlsGroupId)
+        assertNull(payload.reason)
+        assertNull(payload.requestedAt)
+    }
+
+    @Test
+    fun unknownEventDiscriminatorFallsThroughToUnknown() {
+        // Regression gate: an event type the parser does not recognise must
+        // surface as MlsChatRealtimeMessage.Unknown rather than crashing or
+        // silently being treated as a known event.
+        val frame = """
+            {
+              "t": "event",
+              "seq": 5,
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#nonExistentEvent",
+                "cursor": "300",
+                "convoId": "convo-xyz"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Unknown>(msg)
+        assertEquals(5L, msg.seq)
+    }
+
+    @Test
+    fun groupResetEventDoesNotRouteToResetRequestedEvent() {
+        // Cross-contamination gate: the existing `#groupResetEvent` discriminator
+        // must NOT be claimed by the new resetRequestedEvent dispatch case. (The
+        // existing groupResetEvent decode path has a pre-existing latent issue —
+        // missing `@Serializable` on the bridge class — so it falls through to
+        // Unknown rather than producing a typed payload. The point of THIS test
+        // is to ensure the new dispatch case did not steal the routing.)
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#groupResetEvent",
+                "cursor": "400",
+                "convoId": "convo-grp",
+                "newGroupId": "grp-new",
+                "resetGeneration": 2
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        // Must not be the new event, regardless of whether it parses to
+        // MlsChatGroupResetEvent or falls through to Unknown.
+        when (msg) {
+            is MlsChatRealtimeMessage.Event -> assertTrue(
+                msg.payload !is MlsChatResetRequestedEvent,
+                "groupResetEvent payload must not be routed to MlsChatResetRequestedEvent"
+            )
+            is MlsChatRealtimeMessage.Unknown -> { /* acceptable: pre-existing latent bug */ }
+            is MlsChatRealtimeMessage.Error -> error("Unexpected Error: ${msg.error} ${msg.message}")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The codegen for the Phase 2.5 lexicon update (#6, commit 246c38e2) produces
`BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent` in the generated
Kotlin code, but the Android client consumes realtime events through the
**hand-written bridge** in
[`petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt`](https://github.com/joshlacal/Petrel/blob/main/petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt).
That parser had no `MlsChatResetRequestedEvent` data class and no
`parseRealtimeEvent` case for `#resetRequestedEvent`, so events arrived
as `MlsChatRealtimeMessage.Unknown(type, seq)` and the typed payload —
`convoId`, `cryptoSessionId`, `generation`, `trigger`, `requestEventId`,
`expectedNewMlsGroupId`, etc. — was unrecoverable from Kotlin.

This PR adds:

- New `MlsChatResetRequestedEvent` data class mirroring the codegen
  shape (`BlueCatbirdMlsChatSubscribeEventsResetRequestedEvent`) and the
  server's [`StreamEvent::ResetRequestedEvent`](../../mls-ds/server/src/realtime/sse.rs)
  wire emission. Field names match exactly on both sides:
  `cursor`, `convoId`, `cryptoSessionId`, `generation`, `trigger`,
  `requestEventId`, `expectedNewMlsGroupId?`, `reason?`, `requestedAt?`.
- A dispatch case in `parseRealtimeEvent` for `#resetRequestedEvent` (matches
  the existing `contains(...)` style, no overlap with other cases).
- JVM test scaffolding (`petrel-kotlin/src/test/...` did not previously
  exist) with four tests covering: full-payload round-trip, optional-field
  absence, unknown-discriminator regression gate, and cross-contamination
  gate vs. the existing `#groupResetEvent`.

After this lands, the Android agent can be re-dispatched and call
`recordResetRequested(...)` with real data.

## Notes / things to review

- **`requestedAt: String?` vs codegen's `ATProtocolDate?`** — The other
  hand-written bridge classes in this file use plain Kotlin types instead
  of codegen's `ATProtocolDate`. Stayed consistent with that convention;
  the codegen still owns the schema-authoritative type.
- **`requestedAt` is nullable here even though `sse.rs` always emits it
  non-`Option<String>`.** The lexicon makes it nullable, so the schema
  wins and the client tolerates absence. Not a blocking mismatch — server
  always emits, client just guards against omission.
- **Pre-existing latent issue (NOT fixed in this PR)** — None of the
  other bridge classes (`MlsChatGroupResetEvent`, `MlsChatReactionEvent`,
  `MlsChatTypingEvent`, ...) carry `@Serializable`. While orienting on
  this task I wrote a probe test that confirmed `MlsChatGroupResetEvent`
  payloads silently fall through to `MlsChatRealtimeMessage.Unknown` at
  runtime because `realtimeJson.decodeFromJsonElement<T>(...)` requires a
  serializer. **The new `MlsChatResetRequestedEvent` IS annotated
  `@Serializable`**, so it works; the others should be annotated in a
  follow-up. The cross-contamination test (`groupResetEventDoesNotRouteToResetRequestedEvent`)
  documents this — it accepts either a typed `MlsChatGroupResetEvent` or
  fall-through to `Unknown` as long as the new dispatch case did not steal
  the routing.

## Test plan

- [x] `cd petrel-kotlin && ./gradlew test` passes (`JAVA_HOME` set to JBR
      21; default Homebrew Java 25 is incompatible with Kotlin 2.0.21
      Gradle plugin).
- [x] `cd petrel-kotlin && ./gradlew build` passes.
- [ ] Re-dispatched Android agent confirms typed `MlsChatResetRequestedEvent`
      arrives end-to-end on a Phase 2.5 reset request emission from `mls-ds`.

Reading order for review:

1. `petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt`
   — the data class addition + dispatch case.
2. `petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatSubscribeEvents.kt`
   line 376 — codegen schema source of truth.
3. `mls-ds/server/src/realtime/sse.rs` line 187 — server wire emission.
4. `petrel-kotlin/src/test/kotlin/com/atproto/client/MlsChatRealtimeTypesTest.kt`
   — new tests.

Don't merge yet — handing back to @joshlacal for review.