### PR TITLE
Petrel-Kotlin: annotate hand-written bridge classes with @Serializable

### DIFF
--- a/petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt
+++ b/petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt
@@ -42,6 +42,7 @@ sealed class MlsChatRealtimeMessage {
 /**
  * A new message was received in a conversation.
  */
+@Serializable
 data class MlsChatMessageEvent(
     val cursor: String,
     val message: BlueCatbirdMlsChatDefsMessageView,
@@ -51,6 +52,7 @@ data class MlsChatMessageEvent(
 /**
  * A reaction was added or removed on a message.
  */
+@Serializable
 data class MlsChatReactionEvent(
     val cursor: String,
     val convoId: String,
@@ -64,6 +66,7 @@ data class MlsChatReactionEvent(
 /**
  * A user started or stopped typing.
  */
+@Serializable
 data class MlsChatTypingEvent(
     val cursor: String,
     val convoId: String,
@@ -74,6 +77,7 @@ data class MlsChatTypingEvent(
 /**
  * An informational event (heartbeat, system notice, or synthesized from other events).
  */
+@Serializable
 data class MlsChatInfoEvent(
     val cursor: String,
     val info: String,
@@ -85,6 +89,7 @@ data class MlsChatInfoEvent(
 /**
  * A user has read messages in a conversation.
  */
+@Serializable
 data class MlsChatReadEvent(
     val cursor: String,
     val convoId: String,
@@ -95,6 +100,7 @@ data class MlsChatReadEvent(
 /**
  * A new device was registered and needs to be added to conversations.
  */
+@Serializable
 data class MlsChatNewDeviceEvent(
     val cursor: String,
     val convoId: String,
@@ -106,6 +112,7 @@ data class MlsChatNewDeviceEvent(
 /**
  * A member joined, left, or was removed from a conversation.
  */
+@Serializable
 data class MlsChatMembershipChangeEvent(
     val cursor: String,
     val convoId: String,
@@ -116,6 +123,7 @@ data class MlsChatMembershipChangeEvent(
 /**
  * An active member should publish fresh GroupInfo for external commit joins.
  */
+@Serializable
 data class MlsChatGroupInfoRefreshRequestedEvent(
     val cursor: String,
     val convoId: String
@@ -124,6 +132,7 @@ data class MlsChatGroupInfoRefreshRequestedEvent(
 /**
  * A member needs to be re-added to the conversation.
  */
+@Serializable
 data class MlsChatReadditionRequestedEvent(
     val cursor: String,
     val convoId: String,
@@ -134,6 +143,7 @@ data class MlsChatReadditionRequestedEvent(
  * A group has been reset by the server (epoch spiral recovery).
  * Clients should set resetPending=true and prepare for External Commit rejoin.
  */
+@Serializable
 data class MlsChatGroupResetEvent(
     val cursor: String,
     val convoId: String,
@@ -162,10 +172,11 @@ data class MlsChatGroupResetEvent(
  * nullable definition.
  *
  * Note: this class is `@Serializable` so that [realtimeJson]'s
- * `decodeFromJsonElement` can construct it. The other hand-written bridge
- * classes in this file are NOT annotated, which leaves them latently
- * unable to decode at runtime — pre-existing issue, out of scope for this
- * PR (see PR description).
+ * `decodeFromJsonElement` can construct it. All other hand-written bridge
+ * classes in this file are also `@Serializable` (added in the
+ * `kotlin/serializable-cleanup-bridge-classes` follow-up PR; before that,
+ * silent fallthrough to `MlsChatRealtimeMessage.Unknown` was the latent
+ * pre-existing issue noted on PR #7).
  */
 @Serializable
 data class MlsChatResetRequestedEvent(
@@ -327,7 +338,10 @@ internal fun parseRealtimeEvent(json: JsonObject): MlsChatRealtimeEvent? {
                 realtimeJson.decodeFromJsonElement<MlsChatInfoEvent>(payload)
             }
             eventType.contains("readEvent", ignoreCase = true) ||
-            eventType.contains("#read") -> {
+            eventType.contains("#readEvent") -> {
+                // Note: was `#read` originally; that prefix shadowed
+                // `#readditionRequestedEvent` and routed it here, where the
+                // wrong-shape decode threw and silently fell through to Unknown.
                 realtimeJson.decodeFromJsonElement<MlsChatReadEvent>(payload)
             }
             eventType.contains("newDeviceEvent", ignoreCase = true) ||

--- a/petrel-kotlin/src/test/kotlin/com/atproto/client/MlsChatRealtimeTypesTest.kt
+++ b/petrel-kotlin/src/test/kotlin/com/atproto/client/MlsChatRealtimeTypesTest.kt
@@ -113,11 +113,12 @@ class MlsChatRealtimeTypesTest {
     @Test
     fun groupResetEventDoesNotRouteToResetRequestedEvent() {
         // Cross-contamination gate: the existing `#groupResetEvent` discriminator
-        // must NOT be claimed by the new resetRequestedEvent dispatch case. (The
-        // existing groupResetEvent decode path has a pre-existing latent issue —
-        // missing `@Serializable` on the bridge class — so it falls through to
-        // Unknown rather than producing a typed payload. The point of THIS test
-        // is to ensure the new dispatch case did not steal the routing.)
+        // must NOT be claimed by the new resetRequestedEvent dispatch case.
+        //
+        // PRE-FIX: this test tolerated `Unknown` because `MlsChatGroupResetEvent`
+        // was missing `@Serializable` and silently fell through. POST-FIX (this
+        // PR): the bridge class is annotated, so the assertion is inverted —
+        // `MlsChatGroupResetEvent` must be produced, not Unknown.
         val frame = """
             {
               "t": "event",
@@ -132,15 +133,310 @@ class MlsChatRealtimeTypesTest {
         """.trimIndent()
 
         val msg = parseRealtimeMessage(frame)
-        // Must not be the new event, regardless of whether it parses to
-        // MlsChatGroupResetEvent or falls through to Unknown.
-        when (msg) {
-            is MlsChatRealtimeMessage.Event -> assertTrue(
-                msg.payload !is MlsChatResetRequestedEvent,
-                "groupResetEvent payload must not be routed to MlsChatResetRequestedEvent"
-            )
-            is MlsChatRealtimeMessage.Unknown -> { /* acceptable: pre-existing latent bug */ }
-            is MlsChatRealtimeMessage.Error -> error("Unexpected Error: ${msg.error} ${msg.message}")
-        }
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        // assertIs alone is sufficient cross-contamination evidence — once the
+        // payload is statically `MlsChatGroupResetEvent`, it provably is not
+        // `MlsChatResetRequestedEvent`.
+        assertIs<MlsChatGroupResetEvent>(payload)
+    }
+
+    // MARK: - Bridge-class @Serializable regression tests
+    //
+    // These tests guard the PR-#7 follow-up cleanup that added `@Serializable`
+    // to every hand-written bridge class. Before that fix, every event below
+    // silently fell through to `MlsChatRealtimeMessage.Unknown` because
+    // `realtimeJson.decodeFromJsonElement<T>` cannot synthesize a serializer
+    // for a non-`@Serializable` data class — the runtime exception was caught
+    // by `parseRealtimeEvent`'s broad `catch` and the event was dropped.
+    //
+    // `MlsChatGroupResetEvent` is the highest-priority case (epoch-spiral
+    // recovery on Android) and gets the deepest coverage; the rest get a
+    // single positive parse to confirm the annotation took effect.
+
+    @Test
+    fun groupResetEventFullPayloadParses() {
+        val frame = """
+            {
+              "t": "event",
+              "seq": 99,
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#groupResetEvent",
+                "cursor": "501",
+                "convoId": "convo-reset",
+                "newGroupId": "grp-new-id",
+                "resetGeneration": 3,
+                "resetBy": "did:plc:resetter",
+                "cipherSuite": "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+                "reason": "epoch spiral recovery"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        assertEquals(99L, msg.seq)
+        val payload = msg.payload
+        assertIs<MlsChatGroupResetEvent>(payload)
+        assertEquals("501", payload.cursor)
+        assertEquals("convo-reset", payload.convoId)
+        assertEquals("grp-new-id", payload.newGroupId)
+        assertEquals(3, payload.resetGeneration)
+        assertEquals("did:plc:resetter", payload.resetBy)
+        assertEquals(
+            "MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519",
+            payload.cipherSuite
+        )
+        assertEquals("epoch spiral recovery", payload.reason)
+    }
+
+    @Test
+    fun groupResetEventMinimalPayloadParses() {
+        // resetBy / cipherSuite / reason are optional in the lexicon.
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#groupResetEvent",
+                "cursor": "502",
+                "convoId": "convo-min",
+                "newGroupId": "grp-min",
+                "resetGeneration": 1
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatGroupResetEvent>(payload)
+        assertEquals("convo-min", payload.convoId)
+        assertEquals("grp-min", payload.newGroupId)
+        assertEquals(1, payload.resetGeneration)
+        assertNull(payload.resetBy)
+        assertNull(payload.cipherSuite)
+        assertNull(payload.reason)
+    }
+
+    @Test
+    fun groupResetEventDoesNotRouteToResetRequestedEventInverse() {
+        // Inverse of `resetRequestedEventFullPayloadParses` — the new
+        // `#resetRequestedEvent` dispatch must not catch `groupResetEvent`
+        // payloads, even now that both decode through `decodeFromJsonElement`.
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#resetRequestedEvent",
+                "cursor": "503",
+                "convoId": "convo-x",
+                "cryptoSessionId": "csess-x",
+                "generation": 4,
+                "trigger": "inline_409",
+                "requestEventId": "evt-x"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        assertTrue(
+            msg.payload !is MlsChatGroupResetEvent,
+            "resetRequestedEvent payload must not be routed to MlsChatGroupResetEvent"
+        )
+    }
+
+    @Test
+    fun reactionEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#reactionEvent",
+                "cursor": "601",
+                "convoId": "convo-r",
+                "messageId": "msg-r",
+                "did": "did:plc:reactor",
+                "emoji": "U+1F44D",
+                "reaction": "thumbs_up",
+                "action": "added"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatReactionEvent>(payload)
+        assertEquals("convo-r", payload.convoId)
+        assertEquals("msg-r", payload.messageId)
+        assertEquals("thumbs_up", payload.reaction)
+        assertEquals("added", payload.action)
+    }
+
+    @Test
+    fun typingEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#typingEvent",
+                "cursor": "701",
+                "convoId": "convo-t",
+                "did": "did:plc:typer",
+                "isTyping": true
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatTypingEvent>(payload)
+        assertEquals("convo-t", payload.convoId)
+        assertEquals(true, payload.isTyping)
+    }
+
+    @Test
+    fun infoEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#infoEvent",
+                "cursor": "801",
+                "info": "heartbeat",
+                "convoId": "convo-i",
+                "infoType": "system",
+                "requestedBy": "did:plc:requester"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatInfoEvent>(payload)
+        assertEquals("heartbeat", payload.info)
+        assertEquals("convo-i", payload.convoId)
+        assertEquals("system", payload.infoType)
+        assertEquals("did:plc:requester", payload.requestedBy)
+    }
+
+    @Test
+    fun readEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#readEvent",
+                "cursor": "901",
+                "convoId": "convo-rd",
+                "did": "did:plc:reader",
+                "messageId": "msg-rd"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatReadEvent>(payload)
+        assertEquals("convo-rd", payload.convoId)
+        assertEquals("msg-rd", payload.messageId)
+    }
+
+    @Test
+    fun newDeviceEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#newDeviceEvent",
+                "cursor": "1001",
+                "convoId": "convo-nd",
+                "userDid": "did:plc:owner",
+                "deviceId": "dev-1",
+                "deviceName": "iPhone"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatNewDeviceEvent>(payload)
+        assertEquals("convo-nd", payload.convoId)
+        assertEquals("did:plc:owner", payload.userDid)
+        assertEquals("dev-1", payload.deviceId)
+        assertEquals("iPhone", payload.deviceName)
+    }
+
+    @Test
+    fun membershipChangeEventParses() {
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#membershipChangeEvent",
+                "cursor": "1101",
+                "convoId": "convo-mc",
+                "did": "did:plc:newcomer",
+                "action": "joined"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatMembershipChangeEvent>(payload)
+        assertEquals("convo-mc", payload.convoId)
+        assertEquals("did:plc:newcomer", payload.did)
+        assertEquals("joined", payload.action)
+    }
+
+    @Test
+    fun groupInfoRefreshRequestedEventParses() {
+        // Lexicon-canonical discriminator is `#groupInfoRefreshRequestedEvent`.
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#groupInfoRefreshRequestedEvent",
+                "cursor": "1201",
+                "convoId": "convo-gi"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatGroupInfoRefreshRequestedEvent>(payload)
+        assertEquals("convo-gi", payload.convoId)
+    }
+
+    @Test
+    fun readditionRequestedEventParses() {
+        // Lexicon-canonical discriminator is `#readditionRequestedEvent`.
+        val frame = """
+            {
+              "t": "event",
+              "payload": {
+                "${'$'}type": "blue.catbird.mlsChat.subscribeEvents#readditionRequestedEvent",
+                "cursor": "1301",
+                "convoId": "convo-rr",
+                "userDid": "did:plc:rejoiner"
+              }
+            }
+        """.trimIndent()
+
+        val msg = parseRealtimeMessage(frame)
+        assertIs<MlsChatRealtimeMessage.Event>(msg)
+        val payload = msg.payload
+        assertIs<MlsChatReadditionRequestedEvent>(payload)
+        assertEquals("convo-rr", payload.convoId)
+        assertEquals("did:plc:rejoiner", payload.userDid)
     }
 }


### PR DESCRIPTION
## Summary

Fixes the latent pre-existing issue called out in #7: every hand-written bridge class in `petrel-kotlin/src/main/kotlin/com/atproto/client/MlsChatRealtimeTypes.kt` except the newly-added `MlsChatResetRequestedEvent` was missing `@Serializable`.

`realtimeJson.decodeFromJsonElement<T>(...)` cannot synthesize a serializer for a non-`@Serializable` class — the decode throws and the broad `catch` in `parseRealtimeEvent` swallows the exception, silently routing every affected event to `MlsChatRealtimeMessage.Unknown` on Android. So legacy MLS-chat SSE/WebSocket event handling was effectively dark for Kotlin clients.

## Bridge classes annotated

- `MlsChatMessageEvent` (defensive — currently constructed manually, but `decodeFromJsonElement` is one refactor away)
- `MlsChatReactionEvent`
- `MlsChatTypingEvent`
- `MlsChatInfoEvent`
- `MlsChatReadEvent`
- `MlsChatNewDeviceEvent`
- `MlsChatMembershipChangeEvent`
- `MlsChatGroupInfoRefreshRequestedEvent`
- `MlsChatReadditionRequestedEvent`
- `MlsChatGroupResetEvent` (highest-impact: epoch-spiral recovery — observed in production conversations)

Annotation only — no field shape changes. Field names already match JSON keys, so no `@SerialName` overrides were needed (kept the diff minimal per "annotation only" guidance).

## Drive-by parser fix

While verifying the new `@Serializable` on `MlsChatReadditionRequestedEvent` actually decodes, I found that the `readEvent` dispatch arm matched `eventType.contains("#read")`, which **also** matches `#readditionRequestedEvent`. So even with `@Serializable`, readdition events would route to the wrong arm, throw on the wrong-shape decode, and fall through to `Unknown`. Tightened the substring check to `#readEvent`. Without this, the new annotation on `MlsChatReadditionRequestedEvent` would be unreachable.

## Tests

- **Inverted** the existing `groupResetEventDoesNotRouteToResetRequestedEvent` test, which previously tolerated `MlsChatRealtimeMessage.Unknown` "as acceptable: pre-existing latent bug" — that branch is now wrong (the bug is fixed) so the test asserts a typed `MlsChatGroupResetEvent` is produced.
- Added thorough coverage for `MlsChatGroupResetEvent` (full payload + minimal optional-fields payload) since it is the highest-impact case.
- Added one positive-parse test for each other annotated bridge class to confirm the annotation took effect.
- Added an inverse cross-contamination test (`#resetRequestedEvent` does not route to `MlsChatGroupResetEvent`).

15/15 tests now pass.

## Test plan

- [x] `./gradlew test build` (JBR21 via `/Applications/Android Studio.app/Contents/jbr/Contents/Home`) — `BUILD SUCCESSFUL`, 15 tests pass
- [x] Confirmed `MlsChatGroupResetEvent` now decodes a full real-shaped payload with all 7 fields populated
- [x] Confirmed minimal-payload `MlsChatGroupResetEvent` (optional `resetBy`/`cipherSuite`/`reason` absent) decodes with nulls
- [x] Confirmed `#readditionRequestedEvent` no longer gets shadowed by the `#read` substring match
- [ ] Smoke-test on Android consumer (out of scope here — this PR is pure Petrel-Kotlin; once merged, Android can re-test SSE event handling)

## Out of scope

- No Swift-side changes
- No generated-code changes
- No restructuring of bridge data classes (only `@Serializable` and the one parser substring tightening)
- Don't merge — review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)