### PR TITLE
Petrel: bootstrapResetGroup output — add `generation` (Swift + Kotlin regen)

### DIFF
--- a/Generator/lexicons/blue/catbird/mlsChat/blue.catbird.mlsChat.bootstrapResetGroup.json
+++ b/Generator/lexicons/blue/catbird/mlsChat/blue.catbird.mlsChat.bootstrapResetGroup.json
@@ -72,6 +72,11 @@
               "type": "ref",
               "ref": "blue.catbird.mlsChat.defs#convoView",
               "description": "The now-bootstrapped conversation view, including the preserved member roster"
+            },
+            "generation": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Generation number of the now-active crypto_session (preserved across self-heal; freshly minted across activate). Clients seed pendingResetGeneration with this value on bootstrap success so subsequent SSE replay events carrying a stale `gen` are short-circuited before destructive recovery (e.g. deleteGroup) fires. Optional for backward compatibility — older clients that miss the field fall back to fetching it via getConversation/getGroupState."
             }
           }
         }

--- a/Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatBootstrapResetGroup.swift
+++ b/Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatBootstrapResetGroup.swift
@@ -171,19 +171,25 @@ public struct Output: ATProtocolCodable {
         
         public let convo: BlueCatbirdMlsChatDefs.ConvoView
         
+        public let generation: Int?
+        
         
         
         // Standard public initializer
         public init(
             
             
-            convo: BlueCatbirdMlsChatDefs.ConvoView
+            convo: BlueCatbirdMlsChatDefs.ConvoView,
+            
+            generation: Int? = nil
             
             
         ) {
             
             
             self.convo = convo
+            
+            self.generation = generation
             
             
         }
@@ -195,6 +201,9 @@ public struct Output: ATProtocolCodable {
             self.convo = try container.decode(BlueCatbirdMlsChatDefs.ConvoView.self, forKey: .convo)
             
             
+            self.generation = try container.decodeIfPresent(Int.self, forKey: .generation)
+            
+            
         }
         
         public func encode(to encoder: Encoder) throws {
@@ -202,6 +211,10 @@ public struct Output: ATProtocolCodable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             
             try container.encode(convo, forKey: .convo)
+            
+            
+            // Encode optional property even if it's an empty array
+            try container.encodeIfPresent(generation, forKey: .generation)
             
             
         }
@@ -216,6 +229,14 @@ public struct Output: ATProtocolCodable {
             map = map.adding(key: "convo", value: convoValue)
             
             
+            
+            if let value = generation {
+                // Encode optional property even if it's an empty array for CBOR
+                let generationValue = try value.toCBORValue()
+                map = map.adding(key: "generation", value: generationValue)
+            }
+            
+            
 
             return map
             
@@ -224,6 +245,7 @@ public struct Output: ATProtocolCodable {
         
         private enum CodingKeys: String, CodingKey {
             case convo
+            case generation
         }
         
     }

--- a/petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatBootstrapResetGroup.kt
+++ b/petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatBootstrapResetGroup.kt
@@ -43,7 +43,8 @@ object BlueCatbirdMlsChatBootstrapResetGroupDefs {
     @Serializable
     data class BlueCatbirdMlsChatBootstrapResetGroupOutput(
 // The now-bootstrapped conversation view, including the preserved member roster        @SerialName("convo")
-        val convo: BlueCatbirdMlsChatDefsConvoView    )
+        val convo: BlueCatbirdMlsChatDefsConvoView,// Generation number of the now-active crypto_session (preserved across self-heal; freshly minted across activate). Clients seed pendingResetGeneration with this value on bootstrap success so subsequent SSE replay events carrying a stale `gen` are short-circuited before destructive recovery (e.g. deleteGroup) fires. Optional for backward compatibility — older clients that miss the field fall back to fetching it via getConversation/getGroupState.        @SerialName("generation")
+        val generation: Int? = null    )
 
 sealed class BlueCatbirdMlsChatBootstrapResetGroupError(val name: String, val description: String?) {
         object BootstrapTargetNotFound: BlueCatbirdMlsChatBootstrapResetGroupError("BootstrapTargetNotFound", "No conversation row matches (originalConvoId, newGroupId). Either the convo doesn't exist, or the post-reset group_id has already been overwritten by a subsequent reset.")


### PR DESCRIPTION
## Summary

Adds an optional `generation` field to the success output of `blue.catbird.mlsChat.bootstrapResetGroup`. iOS clients seed `pendingResetGeneration` with this value on bootstrap success so subsequent SSE replay events carrying a stale `gen` are short-circuited before destructive recovery (`deleteGroup`) fires.

## Why

CLIENT L (#67) + SERVER F (#68) deployed the post-auto-reset self-heal flow. Then a regression: iOS `handleGroupReset` calls `deleteGroup` on the freshly-bootstrapped MLS group BEFORE checking if the incoming `gen` is stale, because the WebSocket replays historical reset events from a stale cursor and `pendingResetGeneration` is nil after `bootstrapResetGroup` (the response doesn't carry the generation). With this field present, iOS sets `pendingResetGeneration = output.generation` immediately on bootstrap success, and the gen-check correctly recognizes replayed events as for the now-current session.

This is the lexicon + Swift/Kotlin regen half of task #75 (CLIENT M / SERVER M). The Rust regen lives in catbird-atproto; the handler change lives in mls-ds (see Cross-references). The iOS consumer (CatbirdMLSCore) reads `output.generation` if present and falls back to `getConversation`/`getGroupState` otherwise — so this PR is non-breaking for older clients.

## Field schema

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `convo` | ref | yes | The now-bootstrapped conversation view (unchanged) |
| `generation` | integer ≥ 0 | no | `crypto_session.generation` of the activated/self-healed session — preserved across self-heal, freshly minted across activate |

## Changes

- `Generator/lexicons/blue/catbird/mlsChat/blue.catbird.mlsChat.bootstrapResetGroup.json`: add `generation` to `output.properties` (NOT in `required`).
- `Sources/Petrel/Generated/Lexicons/Blue/Catbird/BlueCatbirdMlsChatBootstrapResetGroup.swift`: regen — `Output.generation: Int?` with `decodeIfPresent` / `encodeIfPresent` wired.
- `petrel-kotlin/src/main/kotlin/com/atproto/generated/lexicons/blue/catbird/BlueCatbirdMlsChatBootstrapResetGroup.kt`: regen — nullable Kotlin field.

Total regen diff: 3 files, +30 / -2 lines. Output produced by `python3 run.py Generator/lexicons Sources/Petrel/Generated --language both` (reproducible).

## Cross-references

- catbird-atproto regen (Rust types via Jacquard 0.9.5): https://github.com/joshlacal/catbird-atproto branch `lexicon/bootstrap-generation` (PR pending — opens after this lands)
- mls-ds server-half (handler returns the field): https://github.com/joshlacal/mls-ds branch `lexicon/bootstrap-generation` (PR pending)
- iOS client-half (CatbirdMLSCore): in-flight, owned by ios-agent

The merge order is flexible: per task #75 description, iOS uses a graceful fallback if the field isn't yet present.

## Test plan

- [ ] `swift build` succeeds (verified locally: builds cleanly with the new optional field)
- [ ] CatbirdMLSCore consumer compiles after pulling the new Petrel
- [ ] Android/petrel-kotlin compiles with the nullable Kotlin field
- [ ] Manual round-trip: encode/decode an `Output` JSON with and without the `generation` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)