### PR TITLE
generator: strictly decode security-bearing optional refs

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -12,7 +12,7 @@ on:
       - completed
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -29,31 +29,31 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v2.3.0
-      with:
-        swift-version: "6.0.3"
+    - name: Verify Xcode-provided Swift toolchain
+      run: xcrun swift --version
         
     - name: Clean Package Cache
       run: |
-        swift package clean
+        xcrun swift package clean
         
     - name: Build Documentation
       run: |
-        swift package generate-documentation \
+        xcrun swift package \
+          --allow-writing-to-directory "$GITHUB_WORKSPACE/docs-new" \
+          generate-documentation \
           --target Petrel \
           --transform-for-static-hosting \
           --hosting-base-path Petrel \
-          --output-path docs-new \
-          -Xswiftc -strict-concurrency=targeted
+          --output-path "$GITHUB_WORKSPACE/docs-new"
           
     - name: Update docs directory
       run: |
         rm -rf docs/*
-        cp -r docs-new/* docs/
-        rm -rf docs-new
+        cp -r "$GITHUB_WORKSPACE/docs-new/"* docs/
+        rm -rf "$GITHUB_WORKSPACE/docs-new"
         
     - name: Commit documentation updates
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: swift build
       - name: Test
-        run: swift test
+        run: swift test --no-parallel
 
   linux:
     name: Linux build & test
@@ -31,6 +31,9 @@ jobs:
       - name: Install system dependencies
         run: apt-get update && apt-get install -y libsecret-1-dev libglib2.0-dev pkg-config
       - name: Build
-        run: swift build
+        # swift-crypto 3.x key types do not yet satisfy Swift 6.0's Linux
+        # Sendable diagnostics. Keep this compatibility job in Swift 5 mode
+        # until the crypto dependency boundary is migrated.
+        run: swift build -Xswiftc -swift-version -Xswiftc 5
       - name: Test
-        run: swift test
+        run: swift test --no-parallel -Xswiftc -swift-version -Xswiftc 5

--- a/Package.swift
+++ b/Package.swift
@@ -32,12 +32,17 @@ let package = Package(
     targets: [
         // System library for libsecret (Linux only, ignored on other platforms)
         .systemLibrary(
-            name: "CLibSecretShim",
+            name: "CLibSecret",
             pkgConfig: "libsecret-1",
             providers: [
                 .apt(["libsecret-1-dev", "libglib2.0-dev", "pkg-config"]),
                 .yum(["libsecret-devel", "glib2-devel", "pkg-config"]),
             ]
+        ),
+        .target(
+            name: "CLibSecretShim",
+            dependencies: ["CLibSecret"],
+            publicHeadersPath: "."
         ),
 
         .target(

--- a/Sources/CLibSecret/CLibSecret.h
+++ b/Sources/CLibSecret/CLibSecret.h
@@ -1,0 +1,6 @@
+#ifndef CLIBSECRET_H
+#define CLIBSECRET_H
+
+#include <libsecret/secret.h>
+
+#endif

--- a/Sources/CLibSecret/module.modulemap
+++ b/Sources/CLibSecret/module.modulemap
@@ -1,0 +1,5 @@
+module CLibSecret [system] {
+    header "CLibSecret.h"
+    link "secret-1"
+    export *
+}

--- a/Sources/CLibSecretShim/module.modulemap
+++ b/Sources/CLibSecretShim/module.modulemap
@@ -1,8 +1,0 @@
-module CLibSecretShim {
-    header "shim.h"
-    link "secret-1"
-    link "glib-2.0"
-    link "gobject-2.0"
-    link "gio-2.0"
-    export *
-}

--- a/Sources/CLibSecretShim/shim.c
+++ b/Sources/CLibSecretShim/shim.c
@@ -24,18 +24,23 @@ bool secret_store_password_simple(
         }
     };
     
-    // Use the binary variant to store arbitrary data
+    // Use a SecretValue so arbitrary binary data is preserved losslessly.
+    SecretValue *value = secret_value_new(
+        password,
+        (gssize)password_len,
+        "application/octet-stream"
+    );
     gboolean result = secret_password_store_binary_sync(
         &schema,
         SECRET_COLLECTION_DEFAULT,
         label,
-        (const guchar*)password,
-        password_len,
+        value,
         NULL,  // cancellable
         &error,
         attribute_key, attribute_value,
         NULL
     );
+    secret_value_unref(value);
     
     if (error) {
         if (error_message) {
@@ -92,7 +97,7 @@ char* secret_lookup_password_simple(
     }
     
     gsize len;
-    const guchar *data = secret_value_get(value, &len);
+    const gchar *data = secret_value_get(value, &len);
     char *result = malloc(len);
     if (result) {
         memcpy(result, data, len);

--- a/Sources/Petrel/Account/AccountManager.swift
+++ b/Sources/Petrel/Account/AccountManager.swift
@@ -122,8 +122,7 @@ actor AccountManager: AccountManaging {
 
         // Check for DPoP key
         do {
-            _ = try await storage.getDPoPKey(for: did)
-            hasDPoPKey = true
+            hasDPoPKey = try await storage.containsDPoPKey(for: did)
         } catch {
             LogManager.logDebug(
                 "AccountManager - Error checking DPoP key during startup recovery: \(error)"

--- a/Sources/Petrel/Auth/AuthManager.swift
+++ b/Sources/Petrel/Auth/AuthManager.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// Coordinator class that manages authentication strategies.
 /// Holds a reference to the active strategy and forwards all AuthStrategy methods to it.
@@ -14,7 +17,7 @@ actor AuthManager: AuthStrategy {
     // MARK: - Types
 
     /// Authentication mode determining which strategy to use.
-    enum Mode: Sendable, Equatable {
+    enum Mode: Equatable {
         /// Legacy password-based authentication (App Passwords).
         case legacy
         /// Public OAuth for mobile/native apps (PAR + PKCE + DPoP).
@@ -155,7 +158,7 @@ actor AuthManager: AuthStrategy {
                 accountManager: accountManager
             )
 
-        case .cab(let backendURL):
+        case let .cab(backendURL):
             return CABOAuthStrategy(
                 backendURL: backendURL,
                 storage: storage,

--- a/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
+++ b/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
@@ -6,11 +6,9 @@
 //
 
 import Foundation
-import os.log
+import Logging
 
-private let logger = Logger(
-    subsystem: "blue.catbird.Petrel", category: "ConfidentialGatewayStrategy"
-)
+private let logger = Logger(label: "blue.catbird.Petrel.ConfidentialGatewayStrategy")
 
 /// Session information returned by the gateway's /auth/session endpoint.
 public struct GatewaySessionInfo: Codable, Sendable {
@@ -282,7 +280,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
             switch classifyUnauthorizedGatewayResponse(data) {
             case let .terminal(reason):
                 logger.warning(
-                    "Gateway returned terminal auth error (reason: \(reason, privacy: .public)) - clearing local session"
+                    "Gateway returned terminal auth error (reason: \(reason)) - clearing local session"
                 )
                 await clearCurrentGatewaySession()
                 throw GatewayError.sessionExpired
@@ -290,7 +288,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
             case let .transient(reason):
                 let bodyPreview = String((String(data: data, encoding: .utf8) ?? "").prefix(200))
                 logger.warning(
-                    "Gateway returned transient 401 (reason: \(reason, privacy: .public)) - preserving session. Body: \(bodyPreview, privacy: .public)"
+                    "Gateway returned transient 401 (reason: \(reason)) - preserving session. Body: \(bodyPreview)"
                 )
                 throw GatewayError.authenticationRequired
             }
@@ -382,7 +380,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
             try await storage.deleteGatewaySession(for: currentAccount.did)
         } catch {
             logger.error(
-                "Failed to delete gateway session during 401 handling: \(error, privacy: .public)"
+                "Failed to delete gateway session during 401 handling: \(error)"
             )
         }
     }

--- a/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
+++ b/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 import Logging
 
 private let logger = Logger(label: "blue.catbird.Petrel.ConfidentialGatewayStrategy")
@@ -327,7 +330,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
         let errorCode = (payload?.error ?? "").lowercased()
         let message = (payload?.message ?? responseBody).lowercased()
 
-        let terminalCodes: Set<String> = [
+        let terminalCodes: Set = [
             "expiredtoken",
             "invalidtoken",
             "session_expired",
@@ -353,7 +356,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
             return .terminal(reason: "message_indicates_expiry")
         }
 
-        let transientCodes: Set<String> = [
+        let transientCodes: Set = [
             "temporarilyunavailable",
             "use_dpop_nonce",
             "upstream_error",

--- a/Sources/Petrel/Auth/KeychainManager.swift
+++ b/Sources/Petrel/Auth/KeychainManager.swift
@@ -16,6 +16,12 @@ import Synchronization
     import Security
 #endif
 
+#if canImport(Security)
+    typealias PlatformKeychainAccessibility = CFString
+#else
+    typealias PlatformKeychainAccessibility = String
+#endif
+
 enum KeychainError: Error, LocalizedError {
     case itemStoreError(status: Int)
     case itemRetrievalError(status: Int)
@@ -158,13 +164,33 @@ enum KeychainManager {
                 return KeychainError.storageUnavailable(String(describing: underlyingError))
             }
 
-            func store(key _: String, value _: Data, namespace _: String, accessGroup _: String?) throws { throw unavailable() }
-            func retrieve(key _: String, namespace _: String, accessGroup _: String?) throws -> Data { throw unavailable() }
-            func delete(key _: String, namespace _: String, accessGroup _: String?) throws { throw unavailable() }
-            func deleteAll(namespace _: String, accessGroup _: String?) throws { throw unavailable() }
-            func storeDPoPKey(_: P256.Signing.PrivateKey, keyTag _: String, accessGroup _: String?) throws { throw unavailable() }
-            func retrieveDPoPKey(keyTag _: String, accessGroup _: String?) throws -> P256.Signing.PrivateKey { throw unavailable() }
-            func deleteDPoPKey(keyTag _: String, accessGroup _: String?) throws { throw unavailable() }
+            func store(key _: String, value _: Data, namespace _: String, accessGroup _: String?) throws {
+                throw unavailable()
+            }
+
+            func retrieve(key _: String, namespace _: String, accessGroup _: String?) throws -> Data {
+                throw unavailable()
+            }
+
+            func delete(key _: String, namespace _: String, accessGroup _: String?) throws {
+                throw unavailable()
+            }
+
+            func deleteAll(namespace _: String, accessGroup _: String?) throws {
+                throw unavailable()
+            }
+
+            func storeDPoPKey(_: P256.Signing.PrivateKey, keyTag _: String, accessGroup _: String?) throws {
+                throw unavailable()
+            }
+
+            func retrieveDPoPKey(keyTag _: String, accessGroup _: String?) throws -> P256.Signing.PrivateKey {
+                throw unavailable()
+            }
+
+            func deleteDPoPKey(keyTag _: String, accessGroup _: String?) throws {
+                throw unavailable()
+            }
         }
     #endif
 
@@ -228,7 +254,11 @@ enum KeychainManager {
 
     private static func accessGroupAttributes(_ accessGroup: String?) -> [String: Any] {
         guard let accessGroup, !accessGroup.isEmpty else { return [:] }
-        return [kSecAttrAccessGroup as String: accessGroup]
+        #if canImport(Security)
+            return [kSecAttrAccessGroup as String: accessGroup]
+        #else
+            return [:]
+        #endif
     }
 
     private static func isItemNotFound(_ error: Error) -> Bool {
@@ -267,50 +297,54 @@ enum KeychainManager {
 
     /// Clears cached items for a specific namespace
     static func clearCache(forNamespace namespace: String) {
-        // Since NSCache doesn't support partial clearing based on key prefix,
-        // we need a separate approach for namespace-specific clearing
+        #if canImport(Security)
+            // Since NSCache doesn't support partial clearing based on key prefix,
+            // we need a separate approach for namespace-specific clearing
 
-        // Get all keychain items for the namespace and remove them from cache
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-        ]
+            // Get all keychain items for the namespace and remove them from cache
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecMatchLimit as String: kSecMatchLimitAll,
+                kSecReturnAttributes as String: true,
+            ]
 
-        var result: AnyObject?
-        var status = SecItemCopyMatching(query as CFDictionary, &result)
+            var result: AnyObject?
+            var status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        if status == errSecSuccess, let items = result as? [[String: Any]] {
-            for item in items {
-                if let account = item[kSecAttrAccount as String] as? String,
-                   account.hasPrefix("\(namespace).")
-                {
-                    // Remove from data cache
-                    dataCache.removeObject(forKey: account as NSString)
+            if status == errSecSuccess, let items = result as? [[String: Any]] {
+                for item in items {
+                    if let account = item[kSecAttrAccount as String] as? String,
+                       account.hasPrefix("\(namespace).")
+                    {
+                        // Remove from data cache
+                        dataCache.removeObject(forKey: account as NSString)
+                    }
                 }
             }
-        }
 
-        // Do the same for DPoP keys
-        let keysQuery: [String: Any] = [
-            kSecClass as String: kSecClassKey,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
-        ]
+            // Do the same for DPoP keys
+            let keysQuery: [String: Any] = [
+                kSecClass as String: kSecClassKey,
+                kSecMatchLimit as String: kSecMatchLimitAll,
+                kSecReturnAttributes as String: true,
+            ]
 
-        status = SecItemCopyMatching(keysQuery as CFDictionary, &result)
+            status = SecItemCopyMatching(keysQuery as CFDictionary, &result)
 
-        if status == errSecSuccess, let items = result as? [[String: Any]] {
-            for item in items {
-                if let tagData = item[kSecAttrApplicationTag as String] as? Data,
-                   let tagString = String(data: tagData, encoding: .utf8),
-                   tagString.hasPrefix("\(namespace).")
-                {
-                    // Remove from dpop key cache
-                    dpopKeyCache.removeObject(forKey: tagString as NSString)
+            if status == errSecSuccess, let items = result as? [[String: Any]] {
+                for item in items {
+                    if let tagData = item[kSecAttrApplicationTag as String] as? Data,
+                       let tagString = String(data: tagData, encoding: .utf8),
+                       tagString.hasPrefix("\(namespace).")
+                    {
+                        // Remove from dpop key cache
+                        dpopKeyCache.removeObject(forKey: tagString as NSString)
+                    }
                 }
             }
-        }
+        #else
+            clearCacheStorage()
+        #endif
 
         LogManager.logDebug("KeychainManager - Cache cleared for namespace: \(namespace).")
     }
@@ -340,7 +374,7 @@ enum KeychainManager {
         key: String,
         value: Data,
         namespace: String,
-        accessibility: CFString? = nil,
+        accessibility: PlatformKeychainAccessibility? = nil,
         accessGroup: String? = nil
     ) throws {
         let resolvedAccessGroup = resolvedAccessGroup(accessGroup)
@@ -615,20 +649,7 @@ enum KeychainManager {
     /// Deletes DPoP key bindings from the keychain for a specified namespace.
     static func deleteDPoPKeyBindings(namespace: String, accessGroup: String? = nil) throws {
         let bindingsKey = "\(namespace).dpopKeyBindings"
-        let resolvedAccessGroup = resolvedAccessGroup(accessGroup)
-
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: bindingsKey,
-        ].merging(Self.accessGroupAttributes(resolvedAccessGroup)) { _, new in new }
-
-        let status = SecItemDelete(query as CFDictionary)
-        if status != errSecSuccess, status != errSecItemNotFound {
-            LogManager.logError(
-                "KeychainManager - Failed to delete DPoP key bindings for namespace \(namespace). Status: \(status)"
-            )
-            throw KeychainError.itemStoreError(status: Int(status))
-        }
+        try deleteExplicitKey(bindingsKey, accessGroup: accessGroup)
 
         // Remove from cache
         dataCache.removeObject(forKey: bindingsKey as NSString)
@@ -645,20 +666,7 @@ enum KeychainManager {
         accessGroup: String? = nil
     ) throws {
         let bindingsKey = "\(namespace).dpopKeyBindings.\(did)"
-        let resolvedAccessGroup = resolvedAccessGroup(accessGroup)
-
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: bindingsKey,
-        ].merging(Self.accessGroupAttributes(resolvedAccessGroup)) { _, new in new }
-
-        let status = SecItemDelete(query as CFDictionary)
-        if status != errSecSuccess, status != errSecItemNotFound {
-            LogManager.logError(
-                "KeychainManager - Failed to delete DPoP key bindings for DID \(did). Status: \(status)"
-            )
-            throw KeychainError.itemStoreError(status: Int(status))
-        }
+        try deleteExplicitKey(bindingsKey, accessGroup: accessGroup)
 
         // Remove from cache
         dataCache.removeObject(forKey: bindingsKey as NSString)
@@ -702,7 +710,7 @@ enum KeychainManager {
         key: String,
         value: Data,
         namespace: String,
-        accessibility: CFString? = nil,
+        accessibility: PlatformKeychainAccessibility? = nil,
         accessGroup: String? = nil
     ) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -6,11 +6,14 @@
 //
 
 #if canImport(CryptoKit)
-  import CryptoKit
+    import CryptoKit
 #else
-  @preconcurrency import Crypto
+    @preconcurrency import Crypto
 #endif
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 import JSONWebAlgorithms
 import JSONWebKey
 import JSONWebSignature
@@ -22,698 +25,698 @@ import JSONWebSignature
 /// instance of this actor and delegate common work to it while keeping
 /// strategy-specific token exchange / refresh logic in their own actors.
 actor OAuthCore {
-  // MARK: - Dependencies
+    // MARK: - Dependencies
 
-  let storage: KeychainStorage
-  let accountManager: AccountManaging
-  let networkService: NetworkService
-  let oauthConfig: OAuthConfig
-  let didResolver: DIDResolving
+    let storage: KeychainStorage
+    let accountManager: AccountManaging
+    let networkService: NetworkService
+    let oauthConfig: OAuthConfig
+    let didResolver: DIDResolving
 
-  // MARK: - Shared State
+    // MARK: - Shared State
 
-  var refreshCoordinators: [String: TokenRefreshCoordinator] = [:]
-  let refreshCircuitBreaker = RefreshCircuitBreaker()
-  var noncesByThumbprint: [String: [String: String]] = [:]
-  var usedRefreshTokens: Set<String> = []
-  var activeRefreshTasks: [String: Task<TokenRefreshResult, Error>] = [:]
-  var oauthFlowNonces: [String: String] = [:]
-  var ambiguousRefreshUntil: [String: Date] = [:]
-  var nextRefreshResourceOverride: String?
+    var refreshCoordinators: [String: TokenRefreshCoordinator] = [:]
+    let refreshCircuitBreaker = RefreshCircuitBreaker()
+    var noncesByThumbprint: [String: [String: String]] = [:]
+    var usedRefreshTokens: Set<String> = []
+    var activeRefreshTasks: [String: Task<TokenRefreshResult, Error>] = [:]
+    var oauthFlowNonces: [String: String] = [:]
+    var ambiguousRefreshUntil: [String: Date] = [:]
+    var nextRefreshResourceOverride: String?
 
-  /// Sessions that were successfully refreshed server-side but could not be
-  /// persisted to the keychain (e.g. device locked). Held in memory so the
-  /// running process keeps working; `getSession`'s pending-key handling covers
-  /// the next launch. Keyed by DID.
-  var unpersistedSessions: [String: Session] = [:]
+    /// Sessions that were successfully refreshed server-side but could not be
+    /// persisted to the keychain (e.g. device locked). Held in memory so the
+    /// running process keeps working; `getSession`'s pending-key handling covers
+    /// the next launch. Keyed by DID.
+    var unpersistedSessions: [String: Session] = [:]
 
-  /// Upper bound for `usedRefreshTokens`; entries only matter within a process
-  /// lifetime, so the set is cleared when it grows past this.
-  private static let usedRefreshTokenCap = 64
+    /// Upper bound for `usedRefreshTokens`; entries only matter within a process
+    /// lifetime, so the set is cleared when it grows past this.
+    private static let usedRefreshTokenCap = 64
 
-  /// Strategy-specific refresh implementation.
-  /// Set by the owning strategy after init via `setPerformActualRefresh`.
-  var performActualRefresh: (@Sendable (Account, Session) async throws -> TokenRefreshResult)?
+    /// Strategy-specific refresh implementation.
+    /// Set by the owning strategy after init via `setPerformActualRefresh`.
+    var performActualRefresh: (@Sendable (Account, Session) async throws -> TokenRefreshResult)?
 
-  func setPerformActualRefresh(_ closure: @escaping @Sendable (Account, Session) async throws -> TokenRefreshResult) {
-    self.performActualRefresh = closure
-  }
-
-  // MARK: - Initialization
-
-  init(
-    storage: KeychainStorage,
-    accountManager: AccountManaging,
-    networkService: NetworkService,
-    oauthConfig: OAuthConfig,
-    didResolver: DIDResolving
-  ) {
-    self.storage = storage
-    self.accountManager = accountManager
-    self.networkService = networkService
-    self.oauthConfig = oauthConfig
-    self.didResolver = didResolver
-  }
-
-  // MARK: - PKCE Helpers
-
-  func generateCodeVerifier() -> String {
-    let data = Data((0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) })
-    return base64URLEncode(data)
-  }
-
-  func generateCodeChallenge(from verifier: String) -> String {
-    let data = Data(verifier.utf8)
-    let hash = SHA256.hash(data: data)
-    return base64URLEncode(Data(hash))
-  }
-
-  // MARK: - Encoding Helpers
-
-  func base64URLEncode(_ data: Data) -> String {
-    data.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-  }
-
-  func encodeFormData(_ params: [String: String]) -> Data {
-    let queryItems = params.map { key, value in
-      let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
-      let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
-      return "\(escapedKey)=\(escapedValue)"
-    }
-    return queryItems.joined(separator: "&").data(using: .utf8) ?? Data()
-  }
-
-  // MARK: - URL Helpers
-
-  func extractAuthorizationCode(from url: URL) -> String? {
-    URLComponents(url: url, resolvingAgainstBaseURL: false)?
-      .queryItems?
-      .first(where: { $0.name == "code" })?
-      .value
-  }
-
-  func extractState(from url: URL) -> String? {
-    URLComponents(url: url, resolvingAgainstBaseURL: false)?
-      .queryItems?
-      .first(where: { $0.name == "state" })?
-      .value
-  }
-
-  func extractNonceFromHeaders(_ headers: [AnyHashable: Any]) -> String? {
-    for (key, value) in headers {
-      if let keyString = key as? String,
-         keyString.caseInsensitiveCompare("DPoP-Nonce") == .orderedSame
-      {
-        return value as? String
-      }
-    }
-    return nil
-  }
-
-  func canonicalHTU(_ url: URL) -> String {
-    guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-      return url.absoluteString
-    }
-    comps.scheme = comps.scheme?.lowercased()
-    comps.host = comps.host?.lowercased()
-    if (comps.scheme == "https" && comps.port == 443) || (comps.scheme == "http" && comps.port == 80) {
-      comps.port = nil
-    }
-    if comps.path.isEmpty { comps.path = "/" }
-    comps.fragment = nil
-    comps.query = nil
-    return comps.string ?? url.absoluteString
-  }
-
-  func calculateATH(from token: String) -> String {
-    let tokenData = Data(token.utf8)
-    let hash = SHA256.hash(data: tokenData)
-    return base64URLEncode(Data(hash))
-  }
-
-  // MARK: - JWK & Crypto Helpers
-
-  func createJWK(from privateKey: P256.Signing.PrivateKey) throws -> JWK {
-    let publicKey = privateKey.publicKey
-    let x = publicKey.x963Representation.dropFirst().prefix(32)
-    let y = publicKey.x963Representation.suffix(32)
-    return JWK(keyType: .ellipticCurve, curve: .p256, x: x, y: y)
-  }
-
-  func calculateJWKThumbprint(jwk: JWK) throws -> String {
-    let canonicalJWK: [String: String] = [
-      "crv": "P-256",
-      "kty": "EC",
-      "x": jwk.x?.base64URLEscaped() ?? "",
-      "y": jwk.y?.base64URLEscaped() ?? "",
-    ]
-    let jsonString = "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"\(canonicalJWK["x"]!)\",\"y\":\"\(canonicalJWK["y"]!)\"}"
-    let jsonData = Data(jsonString.utf8)
-    let hash = SHA256.hash(data: jsonData)
-    return Data(hash).base64URLEscaped()
-  }
-
-  // MARK: - DPoP Proof Creation
-
-  func createDPoPProof(
-    for method: String,
-    url: String,
-    type: DPoPProofType,
-    accessToken: String? = nil,
-    did: String? = nil,
-    ephemeralKey: P256.Signing.PrivateKey? = nil,
-    nonce: String? = nil
-  ) async throws -> String {
-    var targetDID: String? = did
-    if targetDID == nil {
-      targetDID = await accountManager.getCurrentAccount()?.did
+    func setPerformActualRefresh(_ closure: @escaping @Sendable (Account, Session) async throws -> TokenRefreshResult) {
+        performActualRefresh = closure
     }
 
-    let privateKey: P256.Signing.PrivateKey
-    if let key = ephemeralKey {
-      privateKey = key
-    } else if let currentDID = targetDID {
-      privateKey = try await getOrCreateDPoPKey(for: currentDID)
-    } else {
-      throw AuthError.noActiveAccount
+    // MARK: - Initialization
+
+    init(
+        storage: KeychainStorage,
+        accountManager: AccountManaging,
+        networkService: NetworkService,
+        oauthConfig: OAuthConfig,
+        didResolver: DIDResolving
+    ) {
+        self.storage = storage
+        self.accountManager = accountManager
+        self.networkService = networkService
+        self.oauthConfig = oauthConfig
+        self.didResolver = didResolver
     }
 
-    let jwk = try createJWK(from: privateKey)
-    let keyThumbprint = try calculateJWKThumbprint(jwk: jwk)
+    // MARK: - PKCE Helpers
 
-    var ath: String?
-    if type == .resourceAccess, let token = accessToken {
-      ath = calculateATH(from: token)
+    func generateCodeVerifier() -> String {
+        let data = Data((0 ..< 32).map { _ in UInt8.random(in: 0 ... 255) })
+        return base64URLEncode(data)
     }
 
-    // Determine nonce to use
-    let finalNonce: String?
-    if let explicitNonce = nonce {
-      finalNonce = explicitNonce
-    } else if did == nil && ephemeralKey != nil, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
-      finalNonce = oauthFlowNonces[domain]
-    } else if let targetDID = targetDID, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
-      // Multi-layer nonce retrieval
-      if let jktNonce = noncesByThumbprint[keyThumbprint]?[domain] {
-        finalNonce = jktNonce
-      } else if let persistedJktNonces = try? await storage.getDPoPNoncesByJKT(for: targetDID),
-                let jktPersistentNonce = persistedJktNonces[keyThumbprint]?[domain]
-      {
-        finalNonce = jktPersistentNonce
-      } else if let storedNonces = try? await storage.getDPoPNonces(for: targetDID),
-                let didNonce = storedNonces[domain]
-      {
-        finalNonce = didNonce
-      } else {
-        finalNonce = nil
-      }
-    } else {
-      finalNonce = nil
+    func generateCodeChallenge(from verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hash = SHA256.hash(data: data)
+        return base64URLEncode(Data(hash))
     }
 
-    // Canonicalize HTU
-    let htuValue: String
-    if let urlObj = URL(string: url) {
-      htuValue = canonicalHTU(urlObj)
-    } else {
-      htuValue = url
+    // MARK: - Encoding Helpers
+
+    func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 
-    let payload = DPoPPayload(
-      jti: "\(UUID().uuidString)-\(UInt64.random(in: 0 ... UInt64.max))",
-      htm: method,
-      htu: htuValue,
-      iat: Int(Date().timeIntervalSince1970),
-      exp: Int(Date().timeIntervalSince1970) + 120,
-      ath: ath,
-      nonce: finalNonce
-    )
-
-    let jwtPayloadData = try JSONEncoder().encode(payload)
-
-    let header = DefaultJWSHeaderImpl(
-      algorithm: .ES256,
-      jwk: jwk, type: "dpop+jwt"
-    )
-    let headerData = try JSONEncoder().encode(header)
-    let headerBase64 = headerData.base64URLEscaped()
-
-    let signingInput = "\(headerBase64).\(base64URLEncode(jwtPayloadData))"
-    let signatureData = try privateKey.signature(for: Data(signingInput.utf8))
-    let signatureBase64 = base64URLEncode(signatureData.rawRepresentation)
-
-    return "\(headerBase64).\(base64URLEncode(jwtPayloadData)).\(signatureBase64)"
-  }
-
-  func getOrCreateDPoPKey(for did: String) async throws -> P256.Signing.PrivateKey {
-    do {
-      if let existingKey = try await storage.getDPoPKey(for: did) {
-        return existingKey
-      }
-    } catch {
-      throw AuthError.dpopKeyError
-    }
-
-    // Check if this is an OAuth session that requires a specific key
-    if let session = try? await storage.getSession(for: did), session.tokenType == .dpop {
-      throw AuthError.dpopKeyError
-    }
-
-    let newKey = P256.Signing.PrivateKey()
-    try await storage.saveDPoPKey(newKey, for: did)
-    return newKey
-  }
-
-  func updateDPoPNonceInternal(domain: String, nonce: String, for did: String) async {
-    do {
-      var nonces = try await storage.getDPoPNonces(for: did) ?? [:]
-      nonces[domain] = nonce
-      try await storage.saveDPoPNonces(nonces, for: did)
-    } catch {}
-  }
-
-  // MARK: - Metadata Fetching
-
-  func resolveAuthServer(for pdsURL: URL) async throws -> URL {
-    do {
-      let metadata = try await fetchProtectedResourceMetadata(pdsURL: pdsURL)
-      if let server = metadata.authorizationServers.first { return server }
-    } catch {}
-    return pdsURL
-  }
-
-  func fetchProtectedResourceMetadata(pdsURL: URL) async throws -> ProtectedResourceMetadata {
-    let endpoint = "\(pdsURL.absoluteString)/.well-known/oauth-protected-resource"
-    guard let endpointURL = URL(string: endpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-    let request = URLRequest(url: endpointURL)
-
-    let maxRetries = 3
-    var lastError: Error?
-    for attempt in 1 ... maxRetries {
-      do {
-        let (data, _) = try await networkService.request(request)
-        return try JSONDecoder().decode(ProtectedResourceMetadata.self, from: data)
-      } catch {
-        lastError = error
-        if attempt < maxRetries {
-          let delay = pow(2.0, Double(attempt - 1)) * 0.1
-          try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    func encodeFormData(_ params: [String: String]) -> Data {
+        let queryItems = params.map { key, value in
+            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+            let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+            return "\(escapedKey)=\(escapedValue)"
         }
-      }
+        return queryItems.joined(separator: "&").data(using: .utf8) ?? Data()
     }
-    throw lastError ?? AuthError.networkError(NetworkError.requestFailed)
-  }
 
-  func fetchAuthorizationServerMetadata(authServerURL: URL) async throws -> AuthorizationServerMetadata {
-    let endpoint = "\(authServerURL.absoluteString)/.well-known/oauth-authorization-server"
-    guard let endpointURL = URL(string: endpoint) else {
-      throw AuthError.invalidOAuthConfiguration
+    // MARK: - URL Helpers
+
+    func extractAuthorizationCode(from url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "code" })?
+            .value
     }
-    let request = URLRequest(url: endpointURL)
 
-    let maxRetries = 3
-    var lastError: Error?
-    for attempt in 1 ... maxRetries {
-      do {
-        let (data, _) = try await networkService.request(request)
-        return try JSONDecoder().decode(AuthorizationServerMetadata.self, from: data)
-      } catch {
-        lastError = error
-        if attempt < maxRetries {
-          let delay = pow(2.0, Double(attempt - 1)) * 0.1
-          try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    func extractState(from url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "state" })?
+            .value
+    }
+
+    func extractNonceFromHeaders(_ headers: [AnyHashable: Any]) -> String? {
+        for (key, value) in headers {
+            if let keyString = key as? String,
+               keyString.caseInsensitiveCompare("DPoP-Nonce") == .orderedSame
+            {
+                return value as? String
+            }
         }
-      }
-    }
-    throw lastError ?? AuthError.networkError(NetworkError.requestFailed)
-  }
-
-  /// Builds the form parameters for a pushed authorization request.
-  /// `additionalParameters` (e.g. a confidential client's `client_assertion`)
-  /// override base entries on key collision.
-  func buildPARParameters(
-    codeChallenge: String,
-    identifier: String?,
-    state: String,
-    additionalParameters: [String: String]? = nil
-  ) -> [String: String] {
-    var parameters: [String: String] = [
-      "client_id": oauthConfig.clientId,
-      "redirect_uri": oauthConfig.redirectUri,
-      "response_type": "code",
-      "code_challenge_method": "S256",
-      "code_challenge": codeChallenge,
-      "state": state,
-      "scope": oauthConfig.scope,
-    ]
-
-    if let identifier {
-      parameters["login_hint"] = identifier
+        return nil
     }
 
-    if let additionalParameters {
-      parameters.merge(additionalParameters) { _, new in new }
+    func canonicalHTU(_ url: URL) -> String {
+        guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString
+        }
+        comps.scheme = comps.scheme?.lowercased()
+        comps.host = comps.host?.lowercased()
+        if (comps.scheme == "https" && comps.port == 443) || (comps.scheme == "http" && comps.port == 80) {
+            comps.port = nil
+        }
+        if comps.path.isEmpty { comps.path = "/" }
+        comps.fragment = nil
+        comps.query = nil
+        return comps.string ?? url.absoluteString
     }
 
-    return parameters
-  }
-
-  func pushAuthorizationRequest(
-    codeChallenge: String,
-    identifier: String?,
-    endpoint: String,
-    authServerURL: URL,
-    state: String,
-    ephemeralKeyForFlow: P256.Signing.PrivateKey?,
-    additionalParameters: [String: String]? = nil
-  ) async throws -> (requestURI: String, parNonce: String?) {
-    let parameters = buildPARParameters(
-      codeChallenge: codeChallenge,
-      identifier: identifier,
-      state: state,
-      additionalParameters: additionalParameters
-    )
-
-    let body = encodeFormData(parameters)
-
-    guard let endpointURL = URL(string: endpoint) else {
-      throw AuthError.invalidOAuthConfiguration
+    func calculateATH(from token: String) -> String {
+        let tokenData = Data(token.utf8)
+        let hash = SHA256.hash(data: tokenData)
+        return base64URLEncode(Data(hash))
     }
-    var request = URLRequest(url: endpointURL)
-    request.httpMethod = "POST"
-    request.httpBody = body
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 
-    // DPoP Proof Generation
-    var proofKey: P256.Signing.PrivateKey?
-    let dpopProof: String
+    // MARK: - JWK & Crypto Helpers
 
-    if let providedKey = ephemeralKeyForFlow {
-      proofKey = providedKey
-      dpopProof = try await createDPoPProof(
-        for: "POST", url: endpoint, type: .authorization, ephemeralKey: providedKey
-      )
-    } else {
-      let tempKey = P256.Signing.PrivateKey()
-      proofKey = tempKey
-      dpopProof = try await createDPoPProof(
-        for: "POST", url: endpoint, type: .authorization, ephemeralKey: tempKey
-      )
+    func createJWK(from privateKey: P256.Signing.PrivateKey) throws -> JWK {
+        let publicKey = privateKey.publicKey
+        let x = publicKey.x963Representation.dropFirst().prefix(32)
+        let y = publicKey.x963Representation.suffix(32)
+        return JWK(keyType: .ellipticCurve, curve: .p256, x: x, y: y)
     }
-    request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
 
-    let (data, response) = try await networkService.request(request)
+    func calculateJWKThumbprint(jwk: JWK) throws -> String {
+        let canonicalJWK: [String: String] = [
+            "crv": "P-256",
+            "kty": "EC",
+            "x": jwk.x?.base64URLEscaped() ?? "",
+            "y": jwk.y?.base64URLEscaped() ?? "",
+        ]
+        let jsonString = "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"\(canonicalJWK["x"]!)\",\"y\":\"\(canonicalJWK["y"]!)\"}"
+        let jsonData = Data(jsonString.utf8)
+        let hash = SHA256.hash(data: jsonData)
+        return Data(hash).base64URLEscaped()
+    }
 
-    guard let httpResponse = response as? HTTPURLResponse else { throw AuthError.invalidResponse }
+    // MARK: - DPoP Proof Creation
 
-    if (200 ... 299).contains(httpResponse.statusCode) {
-      guard let parResponse = try? JSONDecoder().decode(PARResponse.self, from: data) else {
-        throw AuthError.invalidResponse
-      }
-      let requestURI = parResponse.requestURI
-      let parNonce = extractNonceFromHeaders(httpResponse.allHeaderFields)
-      return (requestURI, parNonce)
-    } else if httpResponse.statusCode == 400 {
-      let dpopNonceHeader = extractNonceFromHeaders(httpResponse.allHeaderFields)
-      var isNonceError = false
-      if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-         errorResponse.error == "use_dpop_nonce"
-      {
-        isNonceError = true
-      }
-
-      if isNonceError, let receivedNonce = dpopNonceHeader, let key = proofKey {
-        // Retry with nonce
-        var retryRequest = request
-        let retryProof = try await createDPoPProof(
-          for: "POST", url: endpoint, type: .authorization, ephemeralKey: key, nonce: receivedNonce
-        )
-        retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
-
-        let (retryData, retryResponse) = try await networkService.request(retryRequest)
-        guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
-          throw AuthError.invalidResponse
+    func createDPoPProof(
+        for method: String,
+        url: String,
+        type: DPoPProofType,
+        accessToken: String? = nil,
+        did: String? = nil,
+        ephemeralKey: P256.Signing.PrivateKey? = nil,
+        nonce: String? = nil
+    ) async throws -> String {
+        var targetDID: String? = did
+        if targetDID == nil {
+            targetDID = await accountManager.getCurrentAccount()?.did
         }
 
-        if (200 ... 299).contains(retryHttpResponse.statusCode) {
-          guard let parResponse = try? JSONDecoder().decode(PARResponse.self, from: retryData) else {
-            throw AuthError.invalidResponse
-          }
-          let parNonce = extractNonceFromHeaders(retryHttpResponse.allHeaderFields)
-          return (parResponse.requestURI, parNonce)
+        let privateKey: P256.Signing.PrivateKey
+        if let key = ephemeralKey {
+            privateKey = key
+        } else if let currentDID = targetDID {
+            privateKey = try await getOrCreateDPoPKey(for: currentDID)
         } else {
-          throw AuthError.authorizationFailed
+            throw AuthError.noActiveAccount
         }
-      } else {
-        throw AuthError.authorizationFailed
-      }
-    } else {
-      throw AuthError.authorizationFailed
-    }
-  }
 
-  func revokeToken(refreshToken: String, endpoint: String, did: String) async {
-    guard let url = URL(string: endpoint) else { return }
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    let params = ["token": refreshToken, "client_id": oauthConfig.clientId]
-    request.httpBody = encodeFormData(params)
+        let jwk = try createJWK(from: privateKey)
+        let keyThumbprint = try calculateJWKThumbprint(jwk: jwk)
 
-    if let proof = try? await createDPoPProof(for: "POST", url: endpoint, type: .tokenRequest, did: did) {
-      request.setValue(proof, forHTTPHeaderField: "DPoP")
-    }
+        var ath: String?
+        if type == .resourceAccess, let token = accessToken {
+            ath = calculateATH(from: token)
+        }
 
-    _ = try? await networkService.request(request)
-  }
+        // Determine nonce to use
+        let finalNonce: String?
+        if let explicitNonce = nonce {
+            finalNonce = explicitNonce
+        } else if did == nil && ephemeralKey != nil, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
+            finalNonce = oauthFlowNonces[domain]
+        } else if let targetDID = targetDID, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
+            // Multi-layer nonce retrieval
+            if let jktNonce = noncesByThumbprint[keyThumbprint]?[domain] {
+                finalNonce = jktNonce
+            } else if let persistedJktNonces = try? await storage.getDPoPNoncesByJKT(for: targetDID),
+                      let jktPersistentNonce = persistedJktNonces[keyThumbprint]?[domain]
+            {
+                finalNonce = jktPersistentNonce
+            } else if let storedNonces = try? await storage.getDPoPNonces(for: targetDID),
+                      let didNonce = storedNonces[domain]
+            {
+                finalNonce = didNonce
+            } else {
+                finalNonce = nil
+            }
+        } else {
+            finalNonce = nil
+        }
 
-  // MARK: - AuthenticationProvider Methods
+        // Canonicalize HTU
+        let htuValue: String
+        if let urlObj = URL(string: url) {
+            htuValue = canonicalHTU(urlObj)
+        } else {
+            htuValue = url
+        }
 
-  func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
-    guard let domain = url.host?.lowercased() else { return }
-
-    // Extract nonce case-insensitively
-    var nonce: String?
-    for (key, value) in headers {
-      if key.caseInsensitiveCompare("DPoP-Nonce") == .orderedSame {
-        nonce = value
-        break
-      }
-    }
-    guard let nonce else { return }
-
-    var targetDID = did
-    if targetDID == nil {
-      targetDID = await accountManager.getCurrentAccount()?.did
-    }
-    guard let resolvedDID = targetDID else { return }
-
-    // Update persistent store
-    var nonces = (try? await storage.getDPoPNonces(for: resolvedDID)) ?? [:]
-    nonces[domain] = nonce
-    try? await storage.saveDPoPNonces(nonces, for: resolvedDID)
-
-    if let jkt {
-      var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: resolvedDID)) ?? [:]
-      var domainMap = jktNonces[jkt] ?? [:]
-      domainMap[domain] = nonce
-      jktNonces[jkt] = domainMap
-      try? await storage.saveDPoPNoncesByJKT(jktNonces, for: resolvedDID)
-
-      // Update memory
-      var memMap = noncesByThumbprint[jkt] ?? [:]
-      memMap[domain] = nonce
-      noncesByThumbprint[jkt] = memMap
-    }
-  }
-
-  func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
-    return try await prepareAuthenticatedRequestWithContext(request).0
-  }
-
-  func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
-    guard let account = await accountManager.getCurrentAccount(),
-          let session = try? await storage.getSession(for: account.did)
-    else {
-      throw AuthError.noActiveAccount
-    }
-
-    var req = request
-    let isTokenEndpoint = account.authorizationServerMetadata?.tokenEndpoint == request.url?.absoluteString
-    let type: DPoPProofType = isTokenEndpoint ? .tokenRequest : .resourceAccess
-
-    // Generate DPoP
-    let proof = try await createDPoPProof(
-      for: request.httpMethod ?? "GET",
-      url: request.url?.absoluteString ?? "",
-      type: type,
-      accessToken: isTokenEndpoint ? nil : session.accessToken,
-      did: account.did
-    )
-    req.setValue(proof, forHTTPHeaderField: "DPoP")
-
-    if !isTokenEndpoint {
-      req.setValue("DPoP \(session.accessToken)", forHTTPHeaderField: "Authorization")
-    }
-
-    // Get JKT for context
-    let key = try await getOrCreateDPoPKey(for: account.did)
-    let jwk = try createJWK(from: key)
-    let thumbprint = try calculateJWKThumbprint(jwk: jwk)
-
-    return (req, AuthContext(did: account.did, jkt: thumbprint))
-  }
-
-  // MARK: - Refresh Coordination
-
-  func tokensExist() async -> Bool {
-    guard let did = await accountManager.getCurrentAccount()?.did else { return false }
-    return (try? await storage.getSession(for: did)) != nil
-  }
-
-  func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
-    try await refreshTokenIfNeeded(forceRefresh: false)
-  }
-
-  func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
-    guard let account = await accountManager.getCurrentAccount(),
-          let session = await currentSession(for: account.did)
-    else {
-      throw AuthError.noActiveAccount
-    }
-
-    let did = account.did
-
-    if let task = activeRefreshTasks[did] { return try await task.value }
-
-    guard let refreshToken = session.refreshToken else { throw AuthError.tokenRefreshFailed }
-    if usedRefreshTokens.contains(refreshToken) { throw AuthError.tokenRefreshFailed }
-
-    // Circuit breaker check
-    guard await refreshCircuitBreaker.canAttemptRefresh(for: did) else { throw AuthError.tokenRefreshFailed }
-
-    // Check expiry
-    if !forceRefresh && !session.isExpiringSoon { return .stillValid }
-
-    guard let performRefresh = performActualRefresh else {
-      throw AuthError.tokenRefreshFailed
-    }
-
-    // Guard against concurrent reuse while the request is in flight. The token is
-    // only treated as permanently consumed when the server definitively used it
-    // (success, or invalid_grant); a transient failure (timeout, offline, 5xx)
-    // must NOT burn it, or every later refresh fails until app restart.
-    if usedRefreshTokens.count > Self.usedRefreshTokenCap {
-      usedRefreshTokens.removeAll()
-    }
-    usedRefreshTokens.insert(refreshToken)
-
-    let task = Task<TokenRefreshResult, Error> {
-      try await performRefresh(account, session)
-    }
-    activeRefreshTasks[did] = task
-    defer { activeRefreshTasks.removeValue(forKey: did) }
-
-    do {
-      return try await task.value
-    } catch {
-      if !Self.isDefinitiveRefreshRejection(error) {
-        usedRefreshTokens.remove(refreshToken)
-      }
-      throw error
-    }
-  }
-
-  /// True when the auth server definitively consumed or revoked the refresh token
-  /// (it must never be retried); false for transient failures that are safe to retry.
-  static func isDefinitiveRefreshRejection(_ error: Error) -> Bool {
-    (error as? AuthError) == .invalidCredentials
-  }
-
-  /// Returns the freshest known session for `did`: an unpersisted in-memory session
-  /// (from a refresh whose keychain save failed) wins over the stored one when newer.
-  /// The stored read bypasses the in-memory cache so a rotation performed by another
-  /// process sharing the access group (e.g. an app extension) is observed before
-  /// this process attempts to rotate an already-consumed token.
-  func currentSession(for did: String) async -> Session? {
-    let stored = try? await storage.getSession(for: did, bypassCache: true)
-    guard let unpersisted = unpersistedSessions[did] else { return stored }
-    if let stored, stored.createdAt >= unpersisted.createdAt {
-      unpersistedSessions.removeValue(forKey: did)
-      return stored
-    }
-    return unpersisted
-  }
-
-  /// Persists a session obtained from a successful token refresh. At this point the
-  /// server has already rotated the (single-use) refresh token, so losing `session`
-  /// means losing the account: retry the atomic save, then fall back to a single-write
-  /// pending key plus an in-memory copy. Persistence failure is deliberately not an
-  /// error — the refresh itself succeeded.
-  func persistRefreshedSession(_ session: Session, for account: Account) async {
-    let did = account.did
-    for attempt in 1 ... 3 {
-      do {
-        try await storage.saveAccountAndSession(account, session: session, for: did)
-        unpersistedSessions.removeValue(forKey: did)
-        return
-      } catch {
-        LogManager.logWarning(
-          "Refreshed-session persist attempt \(attempt)/3 failed for DID: \(LogManager.logDID(did)), error: \(error)"
+        let payload = DPoPPayload(
+            jti: "\(UUID().uuidString)-\(UInt64.random(in: 0 ... UInt64.max))",
+            htm: method,
+            htu: htuValue,
+            iat: Int(Date().timeIntervalSince1970),
+            exp: Int(Date().timeIntervalSince1970) + 120,
+            ath: ath,
+            nonce: finalNonce
         )
-        if attempt < 3 {
-          try? await Task.sleep(nanoseconds: UInt64(attempt) * 150_000_000)
-        }
-      }
+
+        let jwtPayloadData = try JSONEncoder().encode(payload)
+
+        let header = DefaultJWSHeaderImpl(
+            algorithm: .ES256,
+            jwk: jwk, type: "dpop+jwt"
+        )
+        let headerData = try JSONEncoder().encode(header)
+        let headerBase64 = headerData.base64URLEscaped()
+
+        let signingInput = "\(headerBase64).\(base64URLEncode(jwtPayloadData))"
+        let signatureData = try privateKey.signature(for: Data(signingInput.utf8))
+        let signatureBase64 = base64URLEncode(signatureData.rawRepresentation)
+
+        return "\(headerBase64).\(base64URLEncode(jwtPayloadData)).\(signatureBase64)"
     }
 
-    unpersistedSessions[did] = session
-    do {
-      try await storage.savePendingSession(session, for: did)
-      LogManager.logError(
-        "Refreshed session could not be saved atomically for DID: \(LogManager.logDID(did)); wrote pending key and holding in memory"
-      )
-    } catch {
-      LogManager.logError(
-        "CRITICAL: refreshed session for DID: \(LogManager.logDID(did)) could not be persisted at all; holding in memory only. Error: \(error)"
-      )
+    func getOrCreateDPoPKey(for did: String) async throws -> P256.Signing.PrivateKey {
+        do {
+            if let existingKey = try await storage.getDPoPKey(for: did) {
+                return existingKey
+            }
+        } catch {
+            throw AuthError.dpopKeyError
+        }
+
+        // Check if this is an OAuth session that requires a specific key
+        if let session = try? await storage.getSession(for: did), session.tokenType == .dpop {
+            throw AuthError.dpopKeyError
+        }
+
+        let newKey = P256.Signing.PrivateKey()
+        try await storage.saveDPoPKey(newKey, for: did)
+        return newKey
     }
-  }
+
+    func updateDPoPNonceInternal(domain: String, nonce: String, for did: String) async {
+        do {
+            var nonces = try await storage.getDPoPNonces(for: did) ?? [:]
+            nonces[domain] = nonce
+            try await storage.saveDPoPNonces(nonces, for: did)
+        } catch {}
+    }
+
+    // MARK: - Metadata Fetching
+
+    func resolveAuthServer(for pdsURL: URL) async throws -> URL {
+        do {
+            let metadata = try await fetchProtectedResourceMetadata(pdsURL: pdsURL)
+            if let server = metadata.authorizationServers.first { return server }
+        } catch {}
+        return pdsURL
+    }
+
+    func fetchProtectedResourceMetadata(pdsURL: URL) async throws -> ProtectedResourceMetadata {
+        let endpoint = "\(pdsURL.absoluteString)/.well-known/oauth-protected-resource"
+        guard let endpointURL = URL(string: endpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        let request = URLRequest(url: endpointURL)
+
+        let maxRetries = 3
+        var lastError: Error?
+        for attempt in 1 ... maxRetries {
+            do {
+                let (data, _) = try await networkService.request(request)
+                return try JSONDecoder().decode(ProtectedResourceMetadata.self, from: data)
+            } catch {
+                lastError = error
+                if attempt < maxRetries {
+                    let delay = pow(2.0, Double(attempt - 1)) * 0.1
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+            }
+        }
+        throw lastError ?? AuthError.networkError(NetworkError.requestFailed)
+    }
+
+    func fetchAuthorizationServerMetadata(authServerURL: URL) async throws -> AuthorizationServerMetadata {
+        let endpoint = "\(authServerURL.absoluteString)/.well-known/oauth-authorization-server"
+        guard let endpointURL = URL(string: endpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        let request = URLRequest(url: endpointURL)
+
+        let maxRetries = 3
+        var lastError: Error?
+        for attempt in 1 ... maxRetries {
+            do {
+                let (data, _) = try await networkService.request(request)
+                return try JSONDecoder().decode(AuthorizationServerMetadata.self, from: data)
+            } catch {
+                lastError = error
+                if attempt < maxRetries {
+                    let delay = pow(2.0, Double(attempt - 1)) * 0.1
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+            }
+        }
+        throw lastError ?? AuthError.networkError(NetworkError.requestFailed)
+    }
+
+    /// Builds the form parameters for a pushed authorization request.
+    /// `additionalParameters` (e.g. a confidential client's `client_assertion`)
+    /// override base entries on key collision.
+    func buildPARParameters(
+        codeChallenge: String,
+        identifier: String?,
+        state: String,
+        additionalParameters: [String: String]? = nil
+    ) -> [String: String] {
+        var parameters: [String: String] = [
+            "client_id": oauthConfig.clientId,
+            "redirect_uri": oauthConfig.redirectUri,
+            "response_type": "code",
+            "code_challenge_method": "S256",
+            "code_challenge": codeChallenge,
+            "state": state,
+            "scope": oauthConfig.scope,
+        ]
+
+        if let identifier {
+            parameters["login_hint"] = identifier
+        }
+
+        if let additionalParameters {
+            parameters.merge(additionalParameters) { _, new in new }
+        }
+
+        return parameters
+    }
+
+    func pushAuthorizationRequest(
+        codeChallenge: String,
+        identifier: String?,
+        endpoint: String,
+        authServerURL: URL,
+        state: String,
+        ephemeralKeyForFlow: P256.Signing.PrivateKey?,
+        additionalParameters: [String: String]? = nil
+    ) async throws -> (requestURI: String, parNonce: String?) {
+        let parameters = buildPARParameters(
+            codeChallenge: codeChallenge,
+            identifier: identifier,
+            state: state,
+            additionalParameters: additionalParameters
+        )
+
+        let body = encodeFormData(parameters)
+
+        guard let endpointURL = URL(string: endpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        // DPoP Proof Generation
+        var proofKey: P256.Signing.PrivateKey?
+        let dpopProof: String
+
+        if let providedKey = ephemeralKeyForFlow {
+            proofKey = providedKey
+            dpopProof = try await createDPoPProof(
+                for: "POST", url: endpoint, type: .authorization, ephemeralKey: providedKey
+            )
+        } else {
+            let tempKey = P256.Signing.PrivateKey()
+            proofKey = tempKey
+            dpopProof = try await createDPoPProof(
+                for: "POST", url: endpoint, type: .authorization, ephemeralKey: tempKey
+            )
+        }
+        request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
+
+        let (data, response) = try await networkService.request(request)
+
+        guard let httpResponse = response as? HTTPURLResponse else { throw AuthError.invalidResponse }
+
+        if (200 ... 299).contains(httpResponse.statusCode) {
+            guard let parResponse = try? JSONDecoder().decode(PARResponse.self, from: data) else {
+                throw AuthError.invalidResponse
+            }
+            let requestURI = parResponse.requestURI
+            let parNonce = extractNonceFromHeaders(httpResponse.allHeaderFields)
+            return (requestURI, parNonce)
+        } else if httpResponse.statusCode == 400 {
+            let dpopNonceHeader = extractNonceFromHeaders(httpResponse.allHeaderFields)
+            var isNonceError = false
+            if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+               errorResponse.error == "use_dpop_nonce"
+            {
+                isNonceError = true
+            }
+
+            if isNonceError, let receivedNonce = dpopNonceHeader, let key = proofKey {
+                // Retry with nonce
+                var retryRequest = request
+                let retryProof = try await createDPoPProof(
+                    for: "POST", url: endpoint, type: .authorization, ephemeralKey: key, nonce: receivedNonce
+                )
+                retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
+
+                let (retryData, retryResponse) = try await networkService.request(retryRequest)
+                guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+                    throw AuthError.invalidResponse
+                }
+
+                if (200 ... 299).contains(retryHttpResponse.statusCode) {
+                    guard let parResponse = try? JSONDecoder().decode(PARResponse.self, from: retryData) else {
+                        throw AuthError.invalidResponse
+                    }
+                    let parNonce = extractNonceFromHeaders(retryHttpResponse.allHeaderFields)
+                    return (parResponse.requestURI, parNonce)
+                } else {
+                    throw AuthError.authorizationFailed
+                }
+            } else {
+                throw AuthError.authorizationFailed
+            }
+        } else {
+            throw AuthError.authorizationFailed
+        }
+    }
+
+    func revokeToken(refreshToken: String, endpoint: String, did: String) async {
+        guard let url = URL(string: endpoint) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let params = ["token": refreshToken, "client_id": oauthConfig.clientId]
+        request.httpBody = encodeFormData(params)
+
+        if let proof = try? await createDPoPProof(for: "POST", url: endpoint, type: .tokenRequest, did: did) {
+            request.setValue(proof, forHTTPHeaderField: "DPoP")
+        }
+
+        _ = try? await networkService.request(request)
+    }
+
+    // MARK: - AuthenticationProvider Methods
+
+    func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
+        guard let domain = url.host?.lowercased() else { return }
+
+        // Extract nonce case-insensitively
+        var nonce: String?
+        for (key, value) in headers {
+            if key.caseInsensitiveCompare("DPoP-Nonce") == .orderedSame {
+                nonce = value
+                break
+            }
+        }
+        guard let nonce else { return }
+
+        var targetDID = did
+        if targetDID == nil {
+            targetDID = await accountManager.getCurrentAccount()?.did
+        }
+        guard let resolvedDID = targetDID else { return }
+
+        // Update persistent store
+        var nonces = (try? await storage.getDPoPNonces(for: resolvedDID)) ?? [:]
+        nonces[domain] = nonce
+        try? await storage.saveDPoPNonces(nonces, for: resolvedDID)
+
+        if let jkt {
+            var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: resolvedDID)) ?? [:]
+            var domainMap = jktNonces[jkt] ?? [:]
+            domainMap[domain] = nonce
+            jktNonces[jkt] = domainMap
+            try? await storage.saveDPoPNoncesByJKT(jktNonces, for: resolvedDID)
+
+            // Update memory
+            var memMap = noncesByThumbprint[jkt] ?? [:]
+            memMap[domain] = nonce
+            noncesByThumbprint[jkt] = memMap
+        }
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        return try await prepareAuthenticatedRequestWithContext(request).0
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        guard let account = await accountManager.getCurrentAccount(),
+              let session = try? await storage.getSession(for: account.did)
+        else {
+            throw AuthError.noActiveAccount
+        }
+
+        var req = request
+        let isTokenEndpoint = account.authorizationServerMetadata?.tokenEndpoint == request.url?.absoluteString
+        let type: DPoPProofType = isTokenEndpoint ? .tokenRequest : .resourceAccess
+
+        // Generate DPoP
+        let proof = try await createDPoPProof(
+            for: request.httpMethod ?? "GET",
+            url: request.url?.absoluteString ?? "",
+            type: type,
+            accessToken: isTokenEndpoint ? nil : session.accessToken,
+            did: account.did
+        )
+        req.setValue(proof, forHTTPHeaderField: "DPoP")
+
+        if !isTokenEndpoint {
+            req.setValue("DPoP \(session.accessToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        // Get JKT for context
+        let key = try await getOrCreateDPoPKey(for: account.did)
+        let jwk = try createJWK(from: key)
+        let thumbprint = try calculateJWKThumbprint(jwk: jwk)
+
+        return (req, AuthContext(did: account.did, jkt: thumbprint))
+    }
+
+    // MARK: - Refresh Coordination
+
+    func tokensExist() async -> Bool {
+        guard let did = await accountManager.getCurrentAccount()?.did else { return false }
+        return (try? await storage.getSession(for: did)) != nil
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        try await refreshTokenIfNeeded(forceRefresh: false)
+    }
+
+    func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
+        guard let account = await accountManager.getCurrentAccount(),
+              let session = await currentSession(for: account.did)
+        else {
+            throw AuthError.noActiveAccount
+        }
+
+        let did = account.did
+
+        if let task = activeRefreshTasks[did] { return try await task.value }
+
+        guard let refreshToken = session.refreshToken else { throw AuthError.tokenRefreshFailed }
+        if usedRefreshTokens.contains(refreshToken) { throw AuthError.tokenRefreshFailed }
+
+        // Circuit breaker check
+        guard await refreshCircuitBreaker.canAttemptRefresh(for: did) else { throw AuthError.tokenRefreshFailed }
+
+        // Check expiry
+        if !forceRefresh && !session.isExpiringSoon { return .stillValid }
+
+        guard let performRefresh = performActualRefresh else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        // Guard against concurrent reuse while the request is in flight. The token is
+        // only treated as permanently consumed when the server definitively used it
+        // (success, or invalid_grant); a transient failure (timeout, offline, 5xx)
+        // must NOT burn it, or every later refresh fails until app restart.
+        if usedRefreshTokens.count > Self.usedRefreshTokenCap {
+            usedRefreshTokens.removeAll()
+        }
+        usedRefreshTokens.insert(refreshToken)
+
+        let task = Task<TokenRefreshResult, Error> {
+            try await performRefresh(account, session)
+        }
+        activeRefreshTasks[did] = task
+        defer { activeRefreshTasks.removeValue(forKey: did) }
+
+        do {
+            return try await task.value
+        } catch {
+            if !Self.isDefinitiveRefreshRejection(error) {
+                usedRefreshTokens.remove(refreshToken)
+            }
+            throw error
+        }
+    }
+
+    /// True when the auth server definitively consumed or revoked the refresh token
+    /// (it must never be retried); false for transient failures that are safe to retry.
+    static func isDefinitiveRefreshRejection(_ error: Error) -> Bool {
+        (error as? AuthError) == .invalidCredentials
+    }
+
+    /// Returns the freshest known session for `did`: an unpersisted in-memory session
+    /// (from a refresh whose keychain save failed) wins over the stored one when newer.
+    /// The stored read bypasses the in-memory cache so a rotation performed by another
+    /// process sharing the access group (e.g. an app extension) is observed before
+    /// this process attempts to rotate an already-consumed token.
+    func currentSession(for did: String) async -> Session? {
+        let stored = try? await storage.getSession(for: did, bypassCache: true)
+        guard let unpersisted = unpersistedSessions[did] else { return stored }
+        if let stored, stored.createdAt >= unpersisted.createdAt {
+            unpersistedSessions.removeValue(forKey: did)
+            return stored
+        }
+        return unpersisted
+    }
+
+    /// Persists a session obtained from a successful token refresh. At this point the
+    /// server has already rotated the (single-use) refresh token, so losing `session`
+    /// means losing the account: retry the atomic save, then fall back to a single-write
+    /// pending key plus an in-memory copy. Persistence failure is deliberately not an
+    /// error — the refresh itself succeeded.
+    func persistRefreshedSession(_ session: Session, for account: Account) async {
+        let did = account.did
+        for attempt in 1 ... 3 {
+            do {
+                try await storage.saveAccountAndSession(account, session: session, for: did)
+                unpersistedSessions.removeValue(forKey: did)
+                return
+            } catch {
+                LogManager.logWarning(
+                    "Refreshed-session persist attempt \(attempt)/3 failed for DID: \(LogManager.logDID(did)), error: \(error)"
+                )
+                if attempt < 3 {
+                    try? await Task.sleep(nanoseconds: UInt64(attempt) * 150_000_000)
+                }
+            }
+        }
+
+        unpersistedSessions[did] = session
+        do {
+            try await storage.savePendingSession(session, for: did)
+            LogManager.logError(
+                "Refreshed session could not be saved atomically for DID: \(LogManager.logDID(did)); wrote pending key and holding in memory"
+            )
+        } catch {
+            LogManager.logError(
+                "CRITICAL: refreshed session for DID: \(LogManager.logDID(did)) could not be persisted at all; holding in memory only. Error: \(error)"
+            )
+        }
+    }
 }
 
 // MARK: - Supporting Types
 
 private struct DPoPPayload: Encodable {
-  let jti: String
-  let htm: String
-  let htu: String
-  let iat: Int
-  let exp: Int?
-  let ath: String?
-  let nonce: String?
+    let jti: String
+    let htm: String
+    let htu: String
+    let iat: Int
+    let exp: Int?
+    let ath: String?
+    let nonce: String?
 }
 
 private struct PARResponse: Decodable {
-  let requestURI: String
-  let expiresIn: Int
+    let requestURI: String
+    let expiresIn: Int
 
-  enum CodingKeys: String, CodingKey {
-    case requestURI = "request_uri"
-    case expiresIn = "expires_in"
-  }
+    enum CodingKeys: String, CodingKey {
+        case requestURI = "request_uri"
+        case expiresIn = "expires_in"
+    }
 }
 
 struct OAuthErrorResponse: Decodable {
-  let error: String
-  let errorDescription: String?
+    let error: String
+    let errorDescription: String?
 
-  enum CodingKeys: String, CodingKey {
-    case error
-    case errorDescription = "error_description"
-  }
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+    }
 }

--- a/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
@@ -8,25 +8,28 @@
 //
 
 #if canImport(CryptoKit)
-  import CryptoKit
+    import CryptoKit
 #else
-  @preconcurrency import Crypto
+    @preconcurrency import Crypto
 #endif
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 import JSONWebAlgorithms
 import JSONWebKey
 import JSONWebSignature
 
 // MARK: - Client Assertion Response
 
-struct ClientAssertionResponse: Decodable, Sendable {
-  let clientId: String
-  let clientAssertion: String
+struct ClientAssertionResponse: Decodable {
+    let clientId: String
+    let clientAssertion: String
 
-  enum CodingKeys: String, CodingKey {
-    case clientId = "client_id"
-    case clientAssertion = "client_assertion"
-  }
+    enum CodingKeys: String, CodingKey {
+        case clientId = "client_id"
+        case clientAssertion = "client_assertion"
+    }
 }
 
 // MARK: - CABOAuthStrategy
@@ -37,681 +40,681 @@ struct ClientAssertionResponse: Decodable, Sendable {
 /// management, but injects a backend-issued `client_assertion` into
 /// every token exchange and refresh request.
 actor CABOAuthStrategy: AuthStrategy {
-  // MARK: - Properties
+    // MARK: - Properties
 
-  let core: OAuthCore
-  let backendURL: URL
+    let core: OAuthCore
+    let backendURL: URL
 
-  /// Transport for backend assertion fetches — injectable for tests.
-  let urlSession: URLSession
+    /// Transport for backend assertion fetches — injectable for tests.
+    let urlSession: URLSession
 
-  static let clientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    static let clientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
-  // Delegates
-  private weak var progressDelegate: AuthProgressDelegate?
-  private weak var failureDelegate: AuthFailureDelegate?
+    // Delegates
+    private weak var progressDelegate: AuthProgressDelegate?
+    private weak var failureDelegate: AuthFailureDelegate?
 
-  // OAuth flow deduplication state
-  private var oauthStartInProgress = false
-  private var oauthStartTasks: [String: Task<URL, Error>] = [:]
+    // OAuth flow deduplication state
+    private var oauthStartInProgress = false
+    private var oauthStartTasks: [String: Task<URL, Error>] = [:]
 
-  // MARK: - Initialization
+    // MARK: - Initialization
 
-  init(
-    backendURL: URL,
-    storage: KeychainStorage,
-    accountManager: AccountManaging,
-    networkService: NetworkService,
-    oauthConfig: OAuthConfig,
-    didResolver: DIDResolving,
-    urlSession: URLSession = .shared
-  ) {
-    self.backendURL = backendURL
-    self.urlSession = urlSession
-    self.core = OAuthCore(
-      storage: storage,
-      accountManager: accountManager,
-      networkService: networkService,
-      oauthConfig: oauthConfig,
-      didResolver: didResolver
-    )
-  }
-
-  /// Must be called after init to wire up the strategy-specific refresh.
-  private func setupRefreshClosure() async {
-    await core.setPerformActualRefresh { [weak self] account, session in
-      guard let self else { throw AuthError.tokenRefreshFailed }
-      return try await self.performActualRefresh(for: account, session: session)
-    }
-  }
-
-  // MARK: - AuthStrategy Implementation
-
-  func startOAuthFlow(
-    identifier: String?,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> URL {
-    await ensureRefreshClosure()
-
-    let key = identifier?.lowercased() ?? "__signup__"
-
-    if let existing = oauthStartTasks[key] {
-      return try await existing.value
+    init(
+        backendURL: URL,
+        storage: KeychainStorage,
+        accountManager: AccountManaging,
+        networkService: NetworkService,
+        oauthConfig: OAuthConfig,
+        didResolver: DIDResolving,
+        urlSession: URLSession = .shared
+    ) {
+        self.backendURL = backendURL
+        self.urlSession = urlSession
+        core = OAuthCore(
+            storage: storage,
+            accountManager: accountManager,
+            networkService: networkService,
+            oauthConfig: oauthConfig,
+            didResolver: didResolver
+        )
     }
 
-    let task = Task.detached(priority: .userInitiated) { [weak self] () throws -> URL in
-      guard let self else { throw AuthError.invalidOAuthConfiguration }
-      return try await self._startOAuthFlowImpl(
-        identifier: identifier,
-        bskyAppViewDID: bskyAppViewDID,
-        bskyChatDID: bskyChatDID
-      )
-    }
-    oauthStartTasks[key] = task
-    defer { oauthStartTasks.removeValue(forKey: key) }
-    return try await task.value
-  }
-
-  func startOAuthFlowForSignUp(
-    pdsURL: URL?,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> URL {
-    throw AuthError.invalidOAuthConfiguration
-  }
-
-  func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
-    await emitProgress(.exchangingTokens)
-
-    guard let code = await core.extractAuthorizationCode(from: url),
-          let stateToken = await core.extractState(from: url)
-    else { throw AuthError.invalidCallbackURL }
-
-    let storage = await core.storage
-    guard let oauthState = try await storage.getOAuthState(for: stateToken) else {
-      throw AuthError.invalidCallbackURL
+    /// Must be called after init to wire up the strategy-specific refresh.
+    private func setupRefreshClosure() async {
+        await core.setPerformActualRefresh { [weak self] account, session in
+            guard let self else { throw AuthError.tokenRefreshFailed }
+            return try await self.performActualRefresh(for: account, session: session)
+        }
     }
 
-    guard let keyData = oauthState.ephemeralDPoPKey else { throw AuthError.dpopKeyError }
-    let ephemeralKey = try P256.Signing.PrivateKey(rawRepresentation: keyData)
+    // MARK: - AuthStrategy Implementation
 
-    try await storage.deleteOAuthState(for: stateToken)
+    func startOAuthFlow(
+        identifier: String?,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> URL {
+        await ensureRefreshClosure()
 
-    guard let pdsURL = oauthState.targetPDSURL else { throw AuthError.invalidOAuthConfiguration }
-    let authServerURL = try await core.resolveAuthServer(for: pdsURL)
-    let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+        let key = identifier?.lowercased() ?? "__signup__"
 
-    let tokenResponse = try await exchangeCodeForTokens(
-      code: code,
-      codeVerifier: oauthState.codeVerifier,
-      tokenEndpoint: metadata.tokenEndpoint,
-      issuer: metadata.issuer,
-      authServerURL: authServerURL,
-      ephemeralKey: ephemeralKey,
-      initialNonce: oauthState.parResponseNonce,
-      resourceURL: pdsURL
-    )
-
-    guard let did = tokenResponse.sub else { throw AuthError.invalidResponse }
-
-    // Resolve real PDS
-    let didResolver = await core.didResolver
-    let (handle, actualPDS) = try await didResolver.resolveDIDToHandleAndPDSURL(did: did)
-
-    // Persist DPoP Key
-    try await storage.saveDPoPKey(ephemeralKey, for: did)
-
-    // Create Session
-    let session = Session(
-      accessToken: tokenResponse.accessToken,
-      refreshToken: tokenResponse.refreshToken,
-      createdAt: Date(),
-      expiresIn: TimeInterval(tokenResponse.expiresIn),
-      tokenType: .dpop,
-      did: did
-    )
-
-    // Create/Update Account
-    let account = Account(
-      did: did,
-      handle: handle ?? oauthState.initialIdentifier,
-      pdsURL: actualPDS,
-      protectedResourceMetadata: nil,
-      authorizationServerMetadata: metadata,
-      bskyAppViewDID: oauthState.bskyAppViewDID ?? "",
-      bskyChatDID: oauthState.bskyChatDID ?? ""
-    )
-
-    try await storage.saveAccountAndSession(account, session: session, for: did)
-    let accountManager = await core.accountManager
-    try await accountManager.updateAccountFromStorage(did: did)
-    try await accountManager.setCurrentAccount(did: did)
-    let networkService = await core.networkService
-    await networkService.setBaseURL(actualPDS)
-
-    return (did: did, handle: account.handle, pdsURL: actualPDS)
-  }
-
-  func loginWithPassword(
-    identifier: String,
-    password: String,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> (did: String, handle: String?, pdsURL: URL) {
-    throw AuthError.invalidOAuthConfiguration
-  }
-
-  func logout() async throws {
-    let accountManager = await core.accountManager
-    guard let did = await accountManager.getCurrentAccount()?.did else { return }
-
-    let storage = await core.storage
-    // Revoke token if possible
-    if let session = try? await storage.getSession(for: did),
-       let refreshToken = session.refreshToken,
-       let account = await accountManager.getAccount(did: did),
-       let endpoint = account.authorizationServerMetadata?.revocationEndpoint
-    {
-      await core.revokeToken(refreshToken: refreshToken, endpoint: endpoint, did: did)
-    }
-
-    try await storage.deleteSession(for: did)
-    try await storage.deleteDPoPKey(for: did)
-    try await storage.saveDPoPNonces([:], for: did)
-
-    await accountManager.clearCurrentAccount()
-  }
-
-  func cancelOAuthFlow() async {
-    oauthStartTasks.values.forEach { $0.cancel() }
-    oauthStartTasks.removeAll()
-    oauthStartInProgress = false
-  }
-
-  func tokensExist() async -> Bool {
-    await core.tokensExist()
-  }
-
-  func setProgressDelegate(_ delegate: AuthProgressDelegate?) async {
-    progressDelegate = delegate
-  }
-
-  func setFailureDelegate(_ delegate: AuthFailureDelegate?) async {
-    failureDelegate = delegate
-  }
-
-  func attemptRecoveryFromServerFailures(for did: String?) async throws {
-    var targetDID = did
-    if targetDID == nil {
-      targetDID = await core.accountManager.getCurrentAccount()?.did
-    }
-    guard let did = targetDID else { return }
-    await core.refreshCircuitBreaker.reset(for: did)
-    _ = try await refreshTokenIfNeeded(forceRefresh: true)
-  }
-
-  // MARK: - AuthenticationProvider
-
-  func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
-    try await core.prepareAuthenticatedRequest(request)
-  }
-
-  func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
-    try await core.prepareAuthenticatedRequestWithContext(request)
-  }
-
-  func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
-    await ensureRefreshClosure()
-    return try await core.refreshTokenIfNeeded()
-  }
-
-  func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
-    await ensureRefreshClosure()
-    return try await core.refreshTokenIfNeeded(forceRefresh: forceRefresh)
-  }
-
-  func handleUnauthorizedResponse(
-    _ response: HTTPURLResponse,
-    data: Data,
-    for request: URLRequest
-  ) async throws -> (Data, HTTPURLResponse) {
-    guard response.statusCode == 401 else { return (data, response) }
-
-    let result = try await refreshTokenIfNeeded(forceRefresh: true)
-
-    switch result {
-    case .refreshedSuccessfully:
-      let (newReq, _) = try await core.prepareAuthenticatedRequestWithContext(request)
-      let networkService = await core.networkService
-      let result = try await networkService.request(newReq)
-      guard let http = result.1 as? HTTPURLResponse else { throw AuthError.invalidResponse }
-      return (result.0, http)
-    default:
-      throw AuthError.tokenRefreshFailed
-    }
-  }
-
-  func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
-    await core.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
-  }
-
-  // MARK: - Private Helpers (OAuth Flow)
-
-  private var refreshClosureSet = false
-
-  private func ensureRefreshClosure() async {
-    if !refreshClosureSet {
-      refreshClosureSet = true
-      await setupRefreshClosure()
-    }
-  }
-
-  private func _startOAuthFlowImpl(identifier: String?, bskyAppViewDID: String?, bskyChatDID: String?) async throws -> URL {
-    if oauthStartInProgress {
-      try? await Task.sleep(nanoseconds: 100_000_000)
-    }
-    oauthStartInProgress = true
-    defer { oauthStartInProgress = false }
-
-    let didResolver = await core.didResolver
-    let pdsURL: URL
-    if let identifier {
-      await emitProgress(.resolvingHandle(identifier))
-      let did = try await didResolver.resolveHandleToDID(handle: identifier)
-      pdsURL = try await didResolver.resolveDIDToPDSURL(did: did)
-    } else {
-      pdsURL = URL(string: "https://bsky.social")!
-    }
-
-    await emitProgress(.fetchingMetadata(url: pdsURL.absoluteString))
-    let authServerURL = try await core.resolveAuthServer(for: pdsURL)
-    let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
-
-    await emitProgress(.generatingParameters)
-    let codeVerifier = await core.generateCodeVerifier()
-    let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
-    let stateToken = UUID().uuidString
-    let ephemeralKey = P256.Signing.PrivateKey()
-
-    let oauthConfig = await core.oauthConfig
-
-    // Confidential clients authenticate at PAR too. Assertions are
-    // single-use (the AS replay-checks jti), so this one is fetched fresh
-    // and used only for this PAR request.
-    let parAssertion = try await fetchClientAssertion(
-      aud: metadata.issuer, ephemeralKey: ephemeralKey
-    )
-
-    let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
-      codeChallenge: codeChallenge,
-      identifier: identifier,
-      endpoint: metadata.pushedAuthorizationRequestEndpoint,
-      authServerURL: authServerURL,
-      state: stateToken,
-      ephemeralKeyForFlow: ephemeralKey,
-      additionalParameters: [
-        "client_assertion": parAssertion.clientAssertion,
-        "client_assertion_type": Self.clientAssertionTypeJWTBearer,
-      ]
-    )
-
-    let oauthState = OAuthState(
-      stateToken: stateToken,
-      codeVerifier: codeVerifier,
-      createdAt: Date(),
-      initialIdentifier: identifier,
-      targetPDSURL: pdsURL,
-      ephemeralDPoPKey: ephemeralKey.rawRepresentation,
-      parResponseNonce: parNonce,
-      bskyAppViewDID: bskyAppViewDID,
-      bskyChatDID: bskyChatDID
-    )
-    let storage = await core.storage
-    try await storage.saveOAuthState(oauthState)
-
-    guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-    components.queryItems = [
-      URLQueryItem(name: "request_uri", value: requestURI),
-      URLQueryItem(name: "client_id", value: oauthConfig.clientId),
-      URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
-    ]
-
-    guard let url = components.url else { throw AuthError.authorizationFailed }
-    return url
-  }
-
-  // MARK: - Client Assertion Fetch
-
-  /// Fetches a DPoP-bound client assertion for the given authorization
-  /// server issuer. Retries exactly once when the backend answers
-  /// 400 `use_dpop_nonce` with a `DPoP-Nonce` header.
-  func fetchClientAssertion(
-    aud: String,
-    ephemeralKey: P256.Signing.PrivateKey? = nil,
-    did: String? = nil
-  ) async throws -> ClientAssertionResponse {
-    try await fetchClientAssertionAttempt(
-      aud: aud, ephemeralKey: ephemeralKey, did: did, nonce: nil, isRetry: false
-    )
-  }
-
-  private func fetchClientAssertionAttempt(
-    aud: String,
-    ephemeralKey: P256.Signing.PrivateKey?,
-    did: String?,
-    nonce: String?,
-    isRetry: Bool
-  ) async throws -> ClientAssertionResponse {
-    let assertionURL = backendURL.appendingPathComponent("oauth/client-assertion")
-
-    let dpopProof: String
-    if let key = ephemeralKey {
-      dpopProof = try await core.createDPoPProof(
-        for: "POST",
-        url: assertionURL.absoluteString,
-        type: .tokenRequest,
-        did: did,
-        ephemeralKey: key,
-        nonce: nonce
-      )
-    } else if let did {
-      dpopProof = try await core.createDPoPProof(
-        for: "POST",
-        url: assertionURL.absoluteString,
-        type: .tokenRefresh,
-        did: did,
-        nonce: nonce
-      )
-    } else {
-      throw AuthError.dpopKeyError
-    }
-
-    var request = URLRequest(url: assertionURL)
-    request.httpMethod = "POST"
-    request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    request.httpBody = await core.encodeFormData(["aud": aud])
-    request.timeoutInterval = 30.0
-
-    let (data, response) = try await urlSession.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw AuthError.invalidResponse
-    }
-
-    if (200 ..< 300).contains(httpResponse.statusCode) {
-      return try JSONDecoder().decode(ClientAssertionResponse.self, from: data)
-    }
-
-    let oauthError = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data)
-    if !isRetry,
-       oauthError?.error == "use_dpop_nonce",
-       let serverNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
-    {
-      return try await fetchClientAssertionAttempt(
-        aud: aud, ephemeralKey: ephemeralKey, did: did, nonce: serverNonce, isRetry: true
-      )
-    }
-
-    throw AuthError.clientAssertionBackendError(httpResponse.statusCode, oauthError?.error)
-  }
-
-  // MARK: - Token Exchange (Strategy-Specific)
-
-  private func exchangeCodeForTokens(
-    code: String,
-    codeVerifier: String,
-    tokenEndpoint: String,
-    issuer: String,
-    authServerURL: URL,
-    ephemeralKey: P256.Signing.PrivateKey?,
-    initialNonce: String?,
-    resourceURL: URL?
-  ) async throws -> TokenResponse {
-    guard let url = URL(string: tokenEndpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-    guard let key = ephemeralKey else {
-      throw AuthError.dpopKeyError
-    }
-
-    // Fetch client assertion from backend
-    // The AS's PAR nonce is deliberately NOT sent to the backend — backend
-    // nonces come only from the backend's own challenge.
-    let assertionResponse = try await fetchClientAssertion(aud: issuer, ephemeralKey: key)
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = 30.0
-
-    let oauthConfig = await core.oauthConfig
-    var params: [String: String] = [
-      "grant_type": "authorization_code",
-      "code": code,
-      "redirect_uri": oauthConfig.redirectUri,
-      "client_id": assertionResponse.clientId,
-      "code_verifier": codeVerifier,
-      "client_assertion": assertionResponse.clientAssertion,
-      "client_assertion_type": Self.clientAssertionTypeJWTBearer,
-    ]
-    if let resourceURL {
-      params["resource"] = resourceURL.absoluteString
-    }
-    request.httpBody = await core.encodeFormData(params)
-
-    return try await sendTokenRequestWithEphemeralKey(
-      request: request,
-      tokenEndpoint: tokenEndpoint,
-      code: code,
-      codeVerifier: codeVerifier,
-      key: key,
-      nonce: initialNonce,
-      clientAssertion: assertionResponse.clientAssertion,
-      clientId: assertionResponse.clientId
-    )
-  }
-
-  private func sendTokenRequestWithEphemeralKey(
-    request baseRequest: URLRequest,
-    tokenEndpoint: String,
-    code: String,
-    codeVerifier: String,
-    key: P256.Signing.PrivateKey,
-    nonce: String?,
-    clientAssertion: String,
-    clientId: String
-  ) async throws -> TokenResponse {
-    var request = baseRequest
-    request.timeoutInterval = 30.0
-
-    let dpopProof = try await core.createDPoPProof(
-      for: "POST",
-      url: tokenEndpoint,
-      type: .tokenRequest,
-      did: nil,
-      ephemeralKey: key,
-      nonce: nonce
-    )
-    request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
-
-    do {
-      let networkService = await core.networkService
-      let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
-
-      guard let httpResponse = urlResponse as? HTTPURLResponse else {
-        throw AuthError.invalidResponse
-      }
-
-      if (200 ..< 300).contains(httpResponse.statusCode) {
-        return try JSONDecoder().decode(TokenResponse.self, from: data)
-      } else if httpResponse.statusCode == 400 && nonce == nil {
-        // Handle use_dpop_nonce error
-        let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
-        var isNonceError = false
-        if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-           errorResponse.error == "use_dpop_nonce"
-        {
-          isNonceError = true
+        if let existing = oauthStartTasks[key] {
+            return try await existing.value
         }
 
-        if isNonceError, let receivedNonce = dpopNonceHeader {
-          let newDpopProof = try await core.createDPoPProof(
+        let task = Task.detached(priority: .userInitiated) { [weak self] () throws -> URL in
+            guard let self else { throw AuthError.invalidOAuthConfiguration }
+            return try await self._startOAuthFlowImpl(
+                identifier: identifier,
+                bskyAppViewDID: bskyAppViewDID,
+                bskyChatDID: bskyChatDID
+            )
+        }
+        oauthStartTasks[key] = task
+        defer { oauthStartTasks.removeValue(forKey: key) }
+        return try await task.value
+    }
+
+    func startOAuthFlowForSignUp(
+        pdsURL: URL?,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> URL {
+        throw AuthError.invalidOAuthConfiguration
+    }
+
+    func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
+        await emitProgress(.exchangingTokens)
+
+        guard let code = await core.extractAuthorizationCode(from: url),
+              let stateToken = await core.extractState(from: url)
+        else { throw AuthError.invalidCallbackURL }
+
+        let storage = await core.storage
+        guard let oauthState = try await storage.getOAuthState(for: stateToken) else {
+            throw AuthError.invalidCallbackURL
+        }
+
+        guard let keyData = oauthState.ephemeralDPoPKey else { throw AuthError.dpopKeyError }
+        let ephemeralKey = try P256.Signing.PrivateKey(rawRepresentation: keyData)
+
+        try await storage.deleteOAuthState(for: stateToken)
+
+        guard let pdsURL = oauthState.targetPDSURL else { throw AuthError.invalidOAuthConfiguration }
+        let authServerURL = try await core.resolveAuthServer(for: pdsURL)
+        let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+
+        let tokenResponse = try await exchangeCodeForTokens(
+            code: code,
+            codeVerifier: oauthState.codeVerifier,
+            tokenEndpoint: metadata.tokenEndpoint,
+            issuer: metadata.issuer,
+            authServerURL: authServerURL,
+            ephemeralKey: ephemeralKey,
+            initialNonce: oauthState.parResponseNonce,
+            resourceURL: pdsURL
+        )
+
+        guard let did = tokenResponse.sub else { throw AuthError.invalidResponse }
+
+        // Resolve real PDS
+        let didResolver = await core.didResolver
+        let (handle, actualPDS) = try await didResolver.resolveDIDToHandleAndPDSURL(did: did)
+
+        // Persist DPoP Key
+        try await storage.saveDPoPKey(ephemeralKey, for: did)
+
+        // Create Session
+        let session = Session(
+            accessToken: tokenResponse.accessToken,
+            refreshToken: tokenResponse.refreshToken,
+            createdAt: Date(),
+            expiresIn: TimeInterval(tokenResponse.expiresIn),
+            tokenType: .dpop,
+            did: did
+        )
+
+        // Create/Update Account
+        let account = Account(
+            did: did,
+            handle: handle ?? oauthState.initialIdentifier,
+            pdsURL: actualPDS,
+            protectedResourceMetadata: nil,
+            authorizationServerMetadata: metadata,
+            bskyAppViewDID: oauthState.bskyAppViewDID ?? "",
+            bskyChatDID: oauthState.bskyChatDID ?? ""
+        )
+
+        try await storage.saveAccountAndSession(account, session: session, for: did)
+        let accountManager = await core.accountManager
+        try await accountManager.updateAccountFromStorage(did: did)
+        try await accountManager.setCurrentAccount(did: did)
+        let networkService = await core.networkService
+        await networkService.setBaseURL(actualPDS)
+
+        return (did: did, handle: account.handle, pdsURL: actualPDS)
+    }
+
+    func loginWithPassword(
+        identifier: String,
+        password: String,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> (did: String, handle: String?, pdsURL: URL) {
+        throw AuthError.invalidOAuthConfiguration
+    }
+
+    func logout() async throws {
+        let accountManager = await core.accountManager
+        guard let did = await accountManager.getCurrentAccount()?.did else { return }
+
+        let storage = await core.storage
+        // Revoke token if possible
+        if let session = try? await storage.getSession(for: did),
+           let refreshToken = session.refreshToken,
+           let account = await accountManager.getAccount(did: did),
+           let endpoint = account.authorizationServerMetadata?.revocationEndpoint
+        {
+            await core.revokeToken(refreshToken: refreshToken, endpoint: endpoint, did: did)
+        }
+
+        try await storage.deleteSession(for: did)
+        try await storage.deleteDPoPKey(for: did)
+        try await storage.saveDPoPNonces([:], for: did)
+
+        await accountManager.clearCurrentAccount()
+    }
+
+    func cancelOAuthFlow() async {
+        oauthStartTasks.values.forEach { $0.cancel() }
+        oauthStartTasks.removeAll()
+        oauthStartInProgress = false
+    }
+
+    func tokensExist() async -> Bool {
+        await core.tokensExist()
+    }
+
+    func setProgressDelegate(_ delegate: AuthProgressDelegate?) async {
+        progressDelegate = delegate
+    }
+
+    func setFailureDelegate(_ delegate: AuthFailureDelegate?) async {
+        failureDelegate = delegate
+    }
+
+    func attemptRecoveryFromServerFailures(for did: String?) async throws {
+        var targetDID = did
+        if targetDID == nil {
+            targetDID = await core.accountManager.getCurrentAccount()?.did
+        }
+        guard let did = targetDID else { return }
+        await core.refreshCircuitBreaker.reset(for: did)
+        _ = try await refreshTokenIfNeeded(forceRefresh: true)
+    }
+
+    // MARK: - AuthenticationProvider
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        try await core.prepareAuthenticatedRequest(request)
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        try await core.prepareAuthenticatedRequestWithContext(request)
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        await ensureRefreshClosure()
+        return try await core.refreshTokenIfNeeded()
+    }
+
+    func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
+        await ensureRefreshClosure()
+        return try await core.refreshTokenIfNeeded(forceRefresh: forceRefresh)
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        guard response.statusCode == 401 else { return (data, response) }
+
+        let result = try await refreshTokenIfNeeded(forceRefresh: true)
+
+        switch result {
+        case .refreshedSuccessfully:
+            let (newReq, _) = try await core.prepareAuthenticatedRequestWithContext(request)
+            let networkService = await core.networkService
+            let result = try await networkService.request(newReq)
+            guard let http = result.1 as? HTTPURLResponse else { throw AuthError.invalidResponse }
+            return (result.0, http)
+        default:
+            throw AuthError.tokenRefreshFailed
+        }
+    }
+
+    func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
+        await core.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
+    }
+
+    // MARK: - Private Helpers (OAuth Flow)
+
+    private var refreshClosureSet = false
+
+    private func ensureRefreshClosure() async {
+        if !refreshClosureSet {
+            refreshClosureSet = true
+            await setupRefreshClosure()
+        }
+    }
+
+    private func _startOAuthFlowImpl(identifier: String?, bskyAppViewDID: String?, bskyChatDID: String?) async throws -> URL {
+        if oauthStartInProgress {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        oauthStartInProgress = true
+        defer { oauthStartInProgress = false }
+
+        let didResolver = await core.didResolver
+        let pdsURL: URL
+        if let identifier {
+            await emitProgress(.resolvingHandle(identifier))
+            let did = try await didResolver.resolveHandleToDID(handle: identifier)
+            pdsURL = try await didResolver.resolveDIDToPDSURL(did: did)
+        } else {
+            pdsURL = URL(string: "https://bsky.social")!
+        }
+
+        await emitProgress(.fetchingMetadata(url: pdsURL.absoluteString))
+        let authServerURL = try await core.resolveAuthServer(for: pdsURL)
+        let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+
+        await emitProgress(.generatingParameters)
+        let codeVerifier = await core.generateCodeVerifier()
+        let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
+        let stateToken = UUID().uuidString
+        let ephemeralKey = P256.Signing.PrivateKey()
+
+        let oauthConfig = await core.oauthConfig
+
+        // Confidential clients authenticate at PAR too. Assertions are
+        // single-use (the AS replay-checks jti), so this one is fetched fresh
+        // and used only for this PAR request.
+        let parAssertion = try await fetchClientAssertion(
+            aud: metadata.issuer, ephemeralKey: ephemeralKey
+        )
+
+        let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
+            codeChallenge: codeChallenge,
+            identifier: identifier,
+            endpoint: metadata.pushedAuthorizationRequestEndpoint,
+            authServerURL: authServerURL,
+            state: stateToken,
+            ephemeralKeyForFlow: ephemeralKey,
+            additionalParameters: [
+                "client_assertion": parAssertion.clientAssertion,
+                "client_assertion_type": Self.clientAssertionTypeJWTBearer,
+            ]
+        )
+
+        let oauthState = OAuthState(
+            stateToken: stateToken,
+            codeVerifier: codeVerifier,
+            createdAt: Date(),
+            initialIdentifier: identifier,
+            targetPDSURL: pdsURL,
+            ephemeralDPoPKey: ephemeralKey.rawRepresentation,
+            parResponseNonce: parNonce,
+            bskyAppViewDID: bskyAppViewDID,
+            bskyChatDID: bskyChatDID
+        )
+        let storage = await core.storage
+        try await storage.saveOAuthState(oauthState)
+
+        guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        components.queryItems = [
+            URLQueryItem(name: "request_uri", value: requestURI),
+            URLQueryItem(name: "client_id", value: oauthConfig.clientId),
+            URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
+        ]
+
+        guard let url = components.url else { throw AuthError.authorizationFailed }
+        return url
+    }
+
+    // MARK: - Client Assertion Fetch
+
+    /// Fetches a DPoP-bound client assertion for the given authorization
+    /// server issuer. Retries exactly once when the backend answers
+    /// 400 `use_dpop_nonce` with a `DPoP-Nonce` header.
+    func fetchClientAssertion(
+        aud: String,
+        ephemeralKey: P256.Signing.PrivateKey? = nil,
+        did: String? = nil
+    ) async throws -> ClientAssertionResponse {
+        try await fetchClientAssertionAttempt(
+            aud: aud, ephemeralKey: ephemeralKey, did: did, nonce: nil, isRetry: false
+        )
+    }
+
+    private func fetchClientAssertionAttempt(
+        aud: String,
+        ephemeralKey: P256.Signing.PrivateKey?,
+        did: String?,
+        nonce: String?,
+        isRetry: Bool
+    ) async throws -> ClientAssertionResponse {
+        let assertionURL = backendURL.appendingPathComponent("oauth/client-assertion")
+
+        let dpopProof: String
+        if let key = ephemeralKey {
+            dpopProof = try await core.createDPoPProof(
+                for: "POST",
+                url: assertionURL.absoluteString,
+                type: .tokenRequest,
+                did: did,
+                ephemeralKey: key,
+                nonce: nonce
+            )
+        } else if let did {
+            dpopProof = try await core.createDPoPProof(
+                for: "POST",
+                url: assertionURL.absoluteString,
+                type: .tokenRefresh,
+                did: did,
+                nonce: nonce
+            )
+        } else {
+            throw AuthError.dpopKeyError
+        }
+
+        var request = URLRequest(url: assertionURL)
+        request.httpMethod = "POST"
+        request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = await core.encodeFormData(["aud": aud])
+        request.timeoutInterval = 30.0
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+
+        if (200 ..< 300).contains(httpResponse.statusCode) {
+            return try JSONDecoder().decode(ClientAssertionResponse.self, from: data)
+        }
+
+        let oauthError = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data)
+        if !isRetry,
+           oauthError?.error == "use_dpop_nonce",
+           let serverNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
+        {
+            return try await fetchClientAssertionAttempt(
+                aud: aud, ephemeralKey: ephemeralKey, did: did, nonce: serverNonce, isRetry: true
+            )
+        }
+
+        throw AuthError.clientAssertionBackendError(httpResponse.statusCode, oauthError?.error)
+    }
+
+    // MARK: - Token Exchange (Strategy-Specific)
+
+    private func exchangeCodeForTokens(
+        code: String,
+        codeVerifier: String,
+        tokenEndpoint: String,
+        issuer: String,
+        authServerURL: URL,
+        ephemeralKey: P256.Signing.PrivateKey?,
+        initialNonce: String?,
+        resourceURL: URL?
+    ) async throws -> TokenResponse {
+        guard let url = URL(string: tokenEndpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        guard let key = ephemeralKey else {
+            throw AuthError.dpopKeyError
+        }
+
+        // Fetch client assertion from backend
+        // The AS's PAR nonce is deliberately NOT sent to the backend — backend
+        // nonces come only from the backend's own challenge.
+        let assertionResponse = try await fetchClientAssertion(aud: issuer, ephemeralKey: key)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30.0
+
+        let oauthConfig = await core.oauthConfig
+        var params: [String: String] = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": oauthConfig.redirectUri,
+            "client_id": assertionResponse.clientId,
+            "code_verifier": codeVerifier,
+            "client_assertion": assertionResponse.clientAssertion,
+            "client_assertion_type": Self.clientAssertionTypeJWTBearer,
+        ]
+        if let resourceURL {
+            params["resource"] = resourceURL.absoluteString
+        }
+        request.httpBody = await core.encodeFormData(params)
+
+        return try await sendTokenRequestWithEphemeralKey(
+            request: request,
+            tokenEndpoint: tokenEndpoint,
+            code: code,
+            codeVerifier: codeVerifier,
+            key: key,
+            nonce: initialNonce,
+            clientAssertion: assertionResponse.clientAssertion,
+            clientId: assertionResponse.clientId
+        )
+    }
+
+    private func sendTokenRequestWithEphemeralKey(
+        request baseRequest: URLRequest,
+        tokenEndpoint: String,
+        code: String,
+        codeVerifier: String,
+        key: P256.Signing.PrivateKey,
+        nonce: String?,
+        clientAssertion: String,
+        clientId: String
+    ) async throws -> TokenResponse {
+        var request = baseRequest
+        request.timeoutInterval = 30.0
+
+        let dpopProof = try await core.createDPoPProof(
             for: "POST",
             url: tokenEndpoint,
             type: .tokenRequest,
             did: nil,
             ephemeralKey: key,
-            nonce: receivedNonce
-          )
-
-          var retryRequest = baseRequest
-          retryRequest.setValue(newDpopProof, forHTTPHeaderField: "DPoP")
-
-          let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
-          guard let retryHttpResponse = retryResponse as? HTTPURLResponse,
-                (200 ..< 300).contains(retryHttpResponse.statusCode)
-          else {
-            throw AuthError.tokenRefreshFailed
-          }
-          return try JSONDecoder().decode(TokenResponse.self, from: retryData)
-        } else {
-          throw AuthError.invalidCredentials
-        }
-      } else {
-        throw AuthError.tokenRefreshFailed
-      }
-    } catch let error as NetworkError {
-      throw AuthError.networkError(error)
-    } catch let error as AuthError {
-      throw error
-    } catch {
-      throw AuthError.tokenRefreshFailed
-    }
-  }
-
-  // MARK: - Token Refresh (Strategy-Specific)
-
-  private func performActualRefresh(for account: Account, session: Session) async throws -> TokenRefreshResult {
-    let data: Data
-    let response: HTTPURLResponse
-    do {
-      (data, response) = try await performTokenRefresh(for: account.did, session: session)
-    } catch let error as NetworkError {
-      // Transport never reached a definitive answer: the refresh token may still be valid.
-      await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .network)
-      throw AuthError.networkError(error)
-    }
-
-    if (200 ..< 300).contains(response.statusCode) {
-      let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
-      let newSession = Session(
-        accessToken: tokenResponse.accessToken,
-        refreshToken: tokenResponse.refreshToken,
-        createdAt: Date(),
-        expiresIn: TimeInterval(tokenResponse.expiresIn),
-        tokenType: session.tokenType,
-        did: account.did
-      )
-      // The server has rotated the refresh token; persistence failures are handled
-      // inside (retry + pending key + in-memory) and must not fail the refresh.
-      await core.persistRefreshedSession(newSession, for: account)
-      await core.refreshCircuitBreaker.recordSuccess(for: account.did)
-      return .refreshedSuccessfully
-    }
-
-    // Distinguish a definitive rejection (token consumed/revoked — never retry it)
-    // from transient server trouble (safe to retry with the same token).
-    if response.statusCode == 400 || response.statusCode == 401,
-       let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-       errorResponse.error == "invalid_grant"
-    {
-      LogManager.logError(
-        "Token refresh definitively rejected (invalid_grant) for DID: \(LogManager.logDID(account.did))"
-      )
-      await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .invalidGrant)
-      throw AuthError.invalidCredentials
-    }
-
-    let kind: RefreshCircuitBreaker.RefreshFailureKind = (500 ..< 600).contains(response.statusCode) ? .server : .other
-    await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: kind)
-    throw AuthError.tokenRefreshFailed
-  }
-
-  private func performTokenRefresh(for did: String, session: Session) async throws -> (Data, HTTPURLResponse) {
-    let accountManager = await core.accountManager
-    guard let account = await accountManager.getAccount(did: did),
-          let metadata = account.authorizationServerMetadata,
-          let refreshToken = session.refreshToken
-    else {
-      throw AuthError.tokenRefreshFailed
-    }
-
-    guard let endpointURL = URL(string: metadata.tokenEndpoint) else {
-      throw AuthError.tokenRefreshFailed
-    }
-
-    // Fetch client assertion from backend
-    let assertionResponse = try await fetchClientAssertion(aud: metadata.issuer, did: did)
-
-    var request = URLRequest(url: endpointURL)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = 30.0
-
-    let params = [
-      "grant_type": "refresh_token",
-      "refresh_token": refreshToken,
-      "client_id": assertionResponse.clientId,
-      "client_assertion": assertionResponse.clientAssertion,
-      "client_assertion_type": Self.clientAssertionTypeJWTBearer,
-    ]
-    request.httpBody = await core.encodeFormData(params)
-
-    let proof = try await core.createDPoPProof(
-      for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
-    )
-    request.setValue(proof, forHTTPHeaderField: "DPoP")
-
-    let networkService = await core.networkService
-    let (data, response) = try await networkService.request(request, skipTokenRefresh: true)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw AuthError.invalidResponse
-    }
-
-    // Handle nonce mismatch with retry
-    if httpResponse.statusCode == 400 {
-      if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-         errorResponse.error == "use_dpop_nonce",
-         let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
-      {
-        // Update nonce and retry
-        if let domain = endpointURL.host?.lowercased() {
-          await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
-        }
-
-        let retryProof = try await core.createDPoPProof(
-          for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+            nonce: nonce
         )
-        var retryRequest = request
-        retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
+        request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
 
-        let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
-        guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
-          throw AuthError.invalidResponse
+        do {
+            let networkService = await core.networkService
+            let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
+
+            guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                throw AuthError.invalidResponse
+            }
+
+            if (200 ..< 300).contains(httpResponse.statusCode) {
+                return try JSONDecoder().decode(TokenResponse.self, from: data)
+            } else if httpResponse.statusCode == 400 && nonce == nil {
+                // Handle use_dpop_nonce error
+                let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
+                var isNonceError = false
+                if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+                   errorResponse.error == "use_dpop_nonce"
+                {
+                    isNonceError = true
+                }
+
+                if isNonceError, let receivedNonce = dpopNonceHeader {
+                    let newDpopProof = try await core.createDPoPProof(
+                        for: "POST",
+                        url: tokenEndpoint,
+                        type: .tokenRequest,
+                        did: nil,
+                        ephemeralKey: key,
+                        nonce: receivedNonce
+                    )
+
+                    var retryRequest = baseRequest
+                    retryRequest.setValue(newDpopProof, forHTTPHeaderField: "DPoP")
+
+                    let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
+                    guard let retryHttpResponse = retryResponse as? HTTPURLResponse,
+                          (200 ..< 300).contains(retryHttpResponse.statusCode)
+                    else {
+                        throw AuthError.tokenRefreshFailed
+                    }
+                    return try JSONDecoder().decode(TokenResponse.self, from: retryData)
+                } else {
+                    throw AuthError.invalidCredentials
+                }
+            } else {
+                throw AuthError.tokenRefreshFailed
+            }
+        } catch let error as NetworkError {
+            throw AuthError.networkError(error)
+        } catch let error as AuthError {
+            throw error
+        } catch {
+            throw AuthError.tokenRefreshFailed
         }
-        return (retryData, retryHttpResponse)
-      }
     }
 
-    return (data, httpResponse)
-  }
+    // MARK: - Token Refresh (Strategy-Specific)
 
-  // MARK: - Progress Helpers
+    private func performActualRefresh(for account: Account, session: Session) async throws -> TokenRefreshResult {
+        let data: Data
+        let response: HTTPURLResponse
+        do {
+            (data, response) = try await performTokenRefresh(for: account.did, session: session)
+        } catch let error as NetworkError {
+            // Transport never reached a definitive answer: the refresh token may still be valid.
+            await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .network)
+            throw AuthError.networkError(error)
+        }
 
-  private func emitProgress(_ event: AuthProgressEvent) async {
-    await progressDelegate?.authenticationProgress(event)
-  }
+        if (200 ..< 300).contains(response.statusCode) {
+            let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+            let newSession = Session(
+                accessToken: tokenResponse.accessToken,
+                refreshToken: tokenResponse.refreshToken,
+                createdAt: Date(),
+                expiresIn: TimeInterval(tokenResponse.expiresIn),
+                tokenType: session.tokenType,
+                did: account.did
+            )
+            // The server has rotated the refresh token; persistence failures are handled
+            // inside (retry + pending key + in-memory) and must not fail the refresh.
+            await core.persistRefreshedSession(newSession, for: account)
+            await core.refreshCircuitBreaker.recordSuccess(for: account.did)
+            return .refreshedSuccessfully
+        }
+
+        // Distinguish a definitive rejection (token consumed/revoked — never retry it)
+        // from transient server trouble (safe to retry with the same token).
+        if response.statusCode == 400 || response.statusCode == 401,
+           let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+           errorResponse.error == "invalid_grant"
+        {
+            LogManager.logError(
+                "Token refresh definitively rejected (invalid_grant) for DID: \(LogManager.logDID(account.did))"
+            )
+            await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .invalidGrant)
+            throw AuthError.invalidCredentials
+        }
+
+        let kind: RefreshCircuitBreaker.RefreshFailureKind = (500 ..< 600).contains(response.statusCode) ? .server : .other
+        await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: kind)
+        throw AuthError.tokenRefreshFailed
+    }
+
+    private func performTokenRefresh(for did: String, session: Session) async throws -> (Data, HTTPURLResponse) {
+        let accountManager = await core.accountManager
+        guard let account = await accountManager.getAccount(did: did),
+              let metadata = account.authorizationServerMetadata,
+              let refreshToken = session.refreshToken
+        else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        guard let endpointURL = URL(string: metadata.tokenEndpoint) else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        // Fetch client assertion from backend
+        let assertionResponse = try await fetchClientAssertion(aud: metadata.issuer, did: did)
+
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30.0
+
+        let params = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": assertionResponse.clientId,
+            "client_assertion": assertionResponse.clientAssertion,
+            "client_assertion_type": Self.clientAssertionTypeJWTBearer,
+        ]
+        request.httpBody = await core.encodeFormData(params)
+
+        let proof = try await core.createDPoPProof(
+            for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+        )
+        request.setValue(proof, forHTTPHeaderField: "DPoP")
+
+        let networkService = await core.networkService
+        let (data, response) = try await networkService.request(request, skipTokenRefresh: true)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+
+        // Handle nonce mismatch with retry
+        if httpResponse.statusCode == 400 {
+            if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+               errorResponse.error == "use_dpop_nonce",
+               let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
+            {
+                // Update nonce and retry
+                if let domain = endpointURL.host?.lowercased() {
+                    await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                }
+
+                let retryProof = try await core.createDPoPProof(
+                    for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+                )
+                var retryRequest = request
+                retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
+
+                let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
+                guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+                    throw AuthError.invalidResponse
+                }
+                return (retryData, retryHttpResponse)
+            }
+        }
+
+        return (data, httpResponse)
+    }
+
+    // MARK: - Progress Helpers
+
+    private func emitProgress(_ event: AuthProgressEvent) async {
+        await progressDelegate?.authenticationProgress(event)
+    }
 }

--- a/Sources/Petrel/Auth/Strategies/LegacyPasswordStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/LegacyPasswordStrategy.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// Authentication strategy for legacy username/password authentication (App Passwords).
 /// Handles:

--- a/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
@@ -6,11 +6,14 @@
 //
 
 #if canImport(CryptoKit)
-  import CryptoKit
+    import CryptoKit
 #else
-  @preconcurrency import Crypto
+    @preconcurrency import Crypto
 #endif
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 import JSONWebAlgorithms
 import JSONWebKey
 import JSONWebSignature
@@ -23,623 +26,623 @@ import JSONWebSignature
 /// - Token Refresh with DPoP Replay Protection
 /// - Automatic DPoP Nonce Handling
 actor PublicOAuthStrategy: AuthStrategy {
-  // MARK: - Properties
+    // MARK: - Properties
 
-  let core: OAuthCore
+    let core: OAuthCore
 
-  // Delegates
-  private weak var progressDelegate: AuthProgressDelegate?
-  private weak var failureDelegate: AuthFailureDelegate?
+    // Delegates
+    private weak var progressDelegate: AuthProgressDelegate?
+    private weak var failureDelegate: AuthFailureDelegate?
 
-  // OAuth flow deduplication state
-  private var oauthStartInProgress = false
-  private var oauthStartTasks: [String: Task<URL, Error>] = [:]
+    // OAuth flow deduplication state
+    private var oauthStartInProgress = false
+    private var oauthStartTasks: [String: Task<URL, Error>] = [:]
 
-  // MARK: - Initialization
+    // MARK: - Initialization
 
-  init(
-    storage: KeychainStorage,
-    accountManager: AccountManaging,
-    networkService: NetworkService,
-    oauthConfig: OAuthConfig,
-    didResolver: DIDResolving
-  ) {
-    self.core = OAuthCore(
-      storage: storage,
-      accountManager: accountManager,
-      networkService: networkService,
-      oauthConfig: oauthConfig,
-      didResolver: didResolver
-    )
-  }
-
-  /// Must be called after init to wire up the strategy-specific refresh.
-  private func setupRefreshClosure() async {
-    await core.setPerformActualRefresh { [weak self] account, session in
-      guard let self else { throw AuthError.tokenRefreshFailed }
-      return try await self.performActualRefresh(for: account, session: session)
-    }
-  }
-
-  // MARK: - AuthStrategy Implementation
-
-  func startOAuthFlow(
-    identifier: String?,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> URL {
-    await ensureRefreshClosure()
-
-    let key = identifier?.lowercased() ?? "__signup__"
-
-    if let existing = oauthStartTasks[key] {
-      return try await existing.value
+    init(
+        storage: KeychainStorage,
+        accountManager: AccountManaging,
+        networkService: NetworkService,
+        oauthConfig: OAuthConfig,
+        didResolver: DIDResolving
+    ) {
+        core = OAuthCore(
+            storage: storage,
+            accountManager: accountManager,
+            networkService: networkService,
+            oauthConfig: oauthConfig,
+            didResolver: didResolver
+        )
     }
 
-    let task = Task.detached(priority: .userInitiated) { [weak self] () throws -> URL in
-      guard let self else { throw AuthError.invalidOAuthConfiguration }
-      return try await self._startOAuthFlowImpl(
-        identifier: identifier,
-        bskyAppViewDID: bskyAppViewDID,
-        bskyChatDID: bskyChatDID
-      )
-    }
-    oauthStartTasks[key] = task
-    defer { oauthStartTasks.removeValue(forKey: key) }
-    return try await task.value
-  }
-
-  func startOAuthFlowForSignUp(
-    pdsURL: URL?,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> URL {
-    let finalPDSURL = pdsURL ?? URL(string: "https://bsky.social")!
-
-    let stateToken = UUID().uuidString
-    let codeVerifier = await core.generateCodeVerifier()
-    let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
-    let ephemeralKey = P256.Signing.PrivateKey()
-
-    let oauthState = OAuthState(
-      stateToken: stateToken,
-      codeVerifier: codeVerifier,
-      createdAt: Date(),
-      initialIdentifier: nil,
-      targetPDSURL: finalPDSURL,
-      ephemeralDPoPKey: ephemeralKey.rawRepresentation,
-      parResponseNonce: nil,
-      bskyAppViewDID: bskyAppViewDID,
-      bskyChatDID: bskyChatDID
-    )
-
-    let authServerURL = try await core.resolveAuthServer(for: finalPDSURL)
-    let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
-
-    let oauthConfig = await core.oauthConfig
-    let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
-      codeChallenge: codeChallenge,
-      identifier: nil,
-      endpoint: metadata.pushedAuthorizationRequestEndpoint,
-      authServerURL: authServerURL,
-      state: stateToken,
-      ephemeralKeyForFlow: ephemeralKey
-    )
-
-    var finalState = oauthState
-    finalState.parResponseNonce = parNonce
-    let storage = await core.storage
-    try await storage.saveOAuthState(finalState)
-
-    guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-    components.queryItems = [
-      URLQueryItem(name: "request_uri", value: requestURI),
-      URLQueryItem(name: "client_id", value: oauthConfig.clientId),
-      URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
-    ]
-
-    guard let url = components.url else { throw AuthError.authorizationFailed }
-    return url
-  }
-
-  func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
-    await emitProgress(.exchangingTokens)
-
-    guard let code = await core.extractAuthorizationCode(from: url),
-          let stateToken = await core.extractState(from: url)
-    else { throw AuthError.invalidCallbackURL }
-
-    let storage = await core.storage
-    guard let oauthState = try await storage.getOAuthState(for: stateToken) else {
-      throw AuthError.invalidCallbackURL
+    /// Must be called after init to wire up the strategy-specific refresh.
+    private func setupRefreshClosure() async {
+        await core.setPerformActualRefresh { [weak self] account, session in
+            guard let self else { throw AuthError.tokenRefreshFailed }
+            return try await self.performActualRefresh(for: account, session: session)
+        }
     }
 
-    guard let keyData = oauthState.ephemeralDPoPKey else { throw AuthError.dpopKeyError }
-    let ephemeralKey = try P256.Signing.PrivateKey(rawRepresentation: keyData)
+    // MARK: - AuthStrategy Implementation
 
-    try await storage.deleteOAuthState(for: stateToken)
+    func startOAuthFlow(
+        identifier: String?,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> URL {
+        await ensureRefreshClosure()
 
-    guard let pdsURL = oauthState.targetPDSURL else { throw AuthError.invalidOAuthConfiguration }
-    let authServerURL = try await core.resolveAuthServer(for: pdsURL)
-    let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+        let key = identifier?.lowercased() ?? "__signup__"
 
-    let tokenResponse = try await exchangeCodeForTokens(
-      code: code,
-      codeVerifier: oauthState.codeVerifier,
-      tokenEndpoint: metadata.tokenEndpoint,
-      authServerURL: authServerURL,
-      ephemeralKey: ephemeralKey,
-      initialNonce: oauthState.parResponseNonce,
-      resourceURL: pdsURL
-    )
-
-    guard let did = tokenResponse.sub else { throw AuthError.invalidResponse }
-
-    // Resolve real PDS
-    let didResolver = await core.didResolver
-    let (handle, actualPDS) = try await didResolver.resolveDIDToHandleAndPDSURL(did: did)
-
-    // Persist DPoP Key
-    try await storage.saveDPoPKey(ephemeralKey, for: did)
-
-    // Create Session
-    let session = Session(
-      accessToken: tokenResponse.accessToken,
-      refreshToken: tokenResponse.refreshToken,
-      createdAt: Date(),
-      expiresIn: TimeInterval(tokenResponse.expiresIn),
-      tokenType: .dpop,
-      did: did
-    )
-
-    // Create/Update Account
-    let account = Account(
-      did: did,
-      handle: handle ?? oauthState.initialIdentifier,
-      pdsURL: actualPDS,
-      protectedResourceMetadata: nil,
-      authorizationServerMetadata: metadata,
-      bskyAppViewDID: oauthState.bskyAppViewDID ?? "",
-      bskyChatDID: oauthState.bskyChatDID ?? ""
-    )
-
-    try await storage.saveAccountAndSession(account, session: session, for: did)
-    let accountManager = await core.accountManager
-    try await accountManager.updateAccountFromStorage(did: did)
-    try await accountManager.setCurrentAccount(did: did)
-    let networkService = await core.networkService
-    await networkService.setBaseURL(actualPDS)
-
-    return (did: did, handle: account.handle, pdsURL: actualPDS)
-  }
-
-  func loginWithPassword(
-    identifier: String,
-    password: String,
-    bskyAppViewDID: String?,
-    bskyChatDID: String?
-  ) async throws -> (did: String, handle: String?, pdsURL: URL) {
-    throw AuthError.invalidOAuthConfiguration // PublicOAuthStrategy doesn't support password login
-  }
-
-  func logout() async throws {
-    let accountManager = await core.accountManager
-    guard let did = await accountManager.getCurrentAccount()?.did else { return }
-
-    let storage = await core.storage
-    // Revoke token if possible
-    if let session = try? await storage.getSession(for: did),
-       let refreshToken = session.refreshToken,
-       let account = await accountManager.getAccount(did: did),
-       let endpoint = account.authorizationServerMetadata?.revocationEndpoint
-    {
-      await core.revokeToken(refreshToken: refreshToken, endpoint: endpoint, did: did)
-    }
-
-    try await storage.deleteSession(for: did)
-    try await storage.deleteDPoPKey(for: did)
-    try await storage.saveDPoPNonces([:], for: did)
-
-    await accountManager.clearCurrentAccount()
-  }
-
-  func cancelOAuthFlow() async {
-    oauthStartTasks.values.forEach { $0.cancel() }
-    oauthStartTasks.removeAll()
-    oauthStartInProgress = false
-  }
-
-  func tokensExist() async -> Bool {
-    await core.tokensExist()
-  }
-
-  func setProgressDelegate(_ delegate: AuthProgressDelegate?) async {
-    progressDelegate = delegate
-  }
-
-  func setFailureDelegate(_ delegate: AuthFailureDelegate?) async {
-    failureDelegate = delegate
-  }
-
-  func attemptRecoveryFromServerFailures(for did: String?) async throws {
-    var targetDID = did
-    if targetDID == nil {
-      targetDID = await core.accountManager.getCurrentAccount()?.did
-    }
-    guard let did = targetDID else { return }
-    await core.refreshCircuitBreaker.reset(for: did)
-    _ = try await refreshTokenIfNeeded(forceRefresh: true)
-  }
-
-  // MARK: - AuthenticationProvider
-
-  func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
-    try await core.prepareAuthenticatedRequest(request)
-  }
-
-  func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
-    try await core.prepareAuthenticatedRequestWithContext(request)
-  }
-
-  func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
-    await ensureRefreshClosure()
-    return try await core.refreshTokenIfNeeded()
-  }
-
-  func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
-    await ensureRefreshClosure()
-    return try await core.refreshTokenIfNeeded(forceRefresh: forceRefresh)
-  }
-
-  func handleUnauthorizedResponse(
-    _ response: HTTPURLResponse,
-    data: Data,
-    for request: URLRequest
-  ) async throws -> (Data, HTTPURLResponse) {
-    guard response.statusCode == 401 else { return (data, response) }
-
-    let result = try await refreshTokenIfNeeded(forceRefresh: true)
-
-    switch result {
-    case .refreshedSuccessfully:
-      let (newReq, _) = try await core.prepareAuthenticatedRequestWithContext(request)
-      let networkService = await core.networkService
-      let result = try await networkService.request(newReq)
-      guard let http = result.1 as? HTTPURLResponse else { throw AuthError.invalidResponse }
-      return (result.0, http)
-    default:
-      throw AuthError.tokenRefreshFailed
-    }
-  }
-
-  func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
-    await core.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
-  }
-
-  // MARK: - Private Helpers (OAuth Flow)
-
-  private var refreshClosureSet = false
-
-  private func ensureRefreshClosure() async {
-    if !refreshClosureSet {
-      refreshClosureSet = true
-      await setupRefreshClosure()
-    }
-  }
-
-  private func _startOAuthFlowImpl(identifier: String?, bskyAppViewDID: String?, bskyChatDID: String?) async throws -> URL {
-    if oauthStartInProgress {
-      try? await Task.sleep(nanoseconds: 100_000_000)
-    }
-    oauthStartInProgress = true
-    defer { oauthStartInProgress = false }
-
-    let didResolver = await core.didResolver
-    let pdsURL: URL
-    if let identifier {
-      await emitProgress(.resolvingHandle(identifier))
-      let did = try await didResolver.resolveHandleToDID(handle: identifier)
-      pdsURL = try await didResolver.resolveDIDToPDSURL(did: did)
-    } else {
-      pdsURL = URL(string: "https://bsky.social")!
-    }
-
-    await emitProgress(.fetchingMetadata(url: pdsURL.absoluteString))
-    let authServerURL = try await core.resolveAuthServer(for: pdsURL)
-    let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
-
-    await emitProgress(.generatingParameters)
-    let codeVerifier = await core.generateCodeVerifier()
-    let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
-    let stateToken = UUID().uuidString
-    let ephemeralKey = P256.Signing.PrivateKey()
-
-    let oauthConfig = await core.oauthConfig
-    let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
-      codeChallenge: codeChallenge,
-      identifier: identifier,
-      endpoint: metadata.pushedAuthorizationRequestEndpoint,
-      authServerURL: authServerURL,
-      state: stateToken,
-      ephemeralKeyForFlow: ephemeralKey
-    )
-
-    let oauthState = OAuthState(
-      stateToken: stateToken,
-      codeVerifier: codeVerifier,
-      createdAt: Date(),
-      initialIdentifier: identifier,
-      targetPDSURL: pdsURL,
-      ephemeralDPoPKey: ephemeralKey.rawRepresentation,
-      parResponseNonce: parNonce,
-      bskyAppViewDID: bskyAppViewDID,
-      bskyChatDID: bskyChatDID
-    )
-    let storage = await core.storage
-    try await storage.saveOAuthState(oauthState)
-
-    guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-    components.queryItems = [
-      URLQueryItem(name: "request_uri", value: requestURI),
-      URLQueryItem(name: "client_id", value: oauthConfig.clientId),
-      URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
-    ]
-
-    guard let url = components.url else { throw AuthError.authorizationFailed }
-    return url
-  }
-
-  // MARK: - Token Exchange (Strategy-Specific)
-
-  private func exchangeCodeForTokens(
-    code: String,
-    codeVerifier: String,
-    tokenEndpoint: String,
-    authServerURL: URL,
-    ephemeralKey: P256.Signing.PrivateKey?,
-    initialNonce: String?,
-    resourceURL: URL?
-  ) async throws -> TokenResponse {
-    guard let url = URL(string: tokenEndpoint) else {
-      throw AuthError.invalidOAuthConfiguration
-    }
-
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = 30.0
-
-    let oauthConfig = await core.oauthConfig
-    var params: [String: String] = [
-      "grant_type": "authorization_code",
-      "code": code,
-      "redirect_uri": oauthConfig.redirectUri,
-      "client_id": oauthConfig.clientId,
-      "code_verifier": codeVerifier,
-    ]
-    if let resourceURL {
-      params["resource"] = resourceURL.absoluteString
-    }
-    request.httpBody = await core.encodeFormData(params)
-
-    if let key = ephemeralKey {
-      return try await sendTokenRequestWithEphemeralKey(
-        request: request,
-        tokenEndpoint: tokenEndpoint,
-        code: code,
-        codeVerifier: codeVerifier,
-        key: key,
-        nonce: initialNonce
-      )
-    } else {
-      // Fallback without DPoP (shouldn't happen in normal flow)
-      let networkService = await core.networkService
-      let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
-      guard let httpResponse = urlResponse as? HTTPURLResponse,
-            (200 ..< 300).contains(httpResponse.statusCode)
-      else {
-        throw AuthError.tokenRefreshFailed
-      }
-      return try JSONDecoder().decode(TokenResponse.self, from: data)
-    }
-  }
-
-  private func sendTokenRequestWithEphemeralKey(
-    request baseRequest: URLRequest,
-    tokenEndpoint: String,
-    code: String,
-    codeVerifier: String,
-    key: P256.Signing.PrivateKey,
-    nonce: String?
-  ) async throws -> TokenResponse {
-    var request = baseRequest
-    request.timeoutInterval = 30.0
-
-    let dpopProof = try await core.createDPoPProof(
-      for: "POST",
-      url: tokenEndpoint,
-      type: .tokenRequest,
-      did: nil,
-      ephemeralKey: key,
-      nonce: nonce
-    )
-    request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
-
-    do {
-      let networkService = await core.networkService
-      let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
-
-      guard let httpResponse = urlResponse as? HTTPURLResponse else {
-        throw AuthError.invalidResponse
-      }
-
-      if (200 ..< 300).contains(httpResponse.statusCode) {
-        return try JSONDecoder().decode(TokenResponse.self, from: data)
-      } else if httpResponse.statusCode == 400 && nonce == nil {
-        // Handle use_dpop_nonce error
-        let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
-        var isNonceError = false
-        if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-           errorResponse.error == "use_dpop_nonce"
-        {
-          isNonceError = true
+        if let existing = oauthStartTasks[key] {
+            return try await existing.value
         }
 
-        if isNonceError, let receivedNonce = dpopNonceHeader {
-          let newDpopProof = try await core.createDPoPProof(
+        let task = Task.detached(priority: .userInitiated) { [weak self] () throws -> URL in
+            guard let self else { throw AuthError.invalidOAuthConfiguration }
+            return try await self._startOAuthFlowImpl(
+                identifier: identifier,
+                bskyAppViewDID: bskyAppViewDID,
+                bskyChatDID: bskyChatDID
+            )
+        }
+        oauthStartTasks[key] = task
+        defer { oauthStartTasks.removeValue(forKey: key) }
+        return try await task.value
+    }
+
+    func startOAuthFlowForSignUp(
+        pdsURL: URL?,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> URL {
+        let finalPDSURL = pdsURL ?? URL(string: "https://bsky.social")!
+
+        let stateToken = UUID().uuidString
+        let codeVerifier = await core.generateCodeVerifier()
+        let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
+        let ephemeralKey = P256.Signing.PrivateKey()
+
+        let oauthState = OAuthState(
+            stateToken: stateToken,
+            codeVerifier: codeVerifier,
+            createdAt: Date(),
+            initialIdentifier: nil,
+            targetPDSURL: finalPDSURL,
+            ephemeralDPoPKey: ephemeralKey.rawRepresentation,
+            parResponseNonce: nil,
+            bskyAppViewDID: bskyAppViewDID,
+            bskyChatDID: bskyChatDID
+        )
+
+        let authServerURL = try await core.resolveAuthServer(for: finalPDSURL)
+        let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+
+        let oauthConfig = await core.oauthConfig
+        let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
+            codeChallenge: codeChallenge,
+            identifier: nil,
+            endpoint: metadata.pushedAuthorizationRequestEndpoint,
+            authServerURL: authServerURL,
+            state: stateToken,
+            ephemeralKeyForFlow: ephemeralKey
+        )
+
+        var finalState = oauthState
+        finalState.parResponseNonce = parNonce
+        let storage = await core.storage
+        try await storage.saveOAuthState(finalState)
+
+        guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        components.queryItems = [
+            URLQueryItem(name: "request_uri", value: requestURI),
+            URLQueryItem(name: "client_id", value: oauthConfig.clientId),
+            URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
+        ]
+
+        guard let url = components.url else { throw AuthError.authorizationFailed }
+        return url
+    }
+
+    func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
+        await emitProgress(.exchangingTokens)
+
+        guard let code = await core.extractAuthorizationCode(from: url),
+              let stateToken = await core.extractState(from: url)
+        else { throw AuthError.invalidCallbackURL }
+
+        let storage = await core.storage
+        guard let oauthState = try await storage.getOAuthState(for: stateToken) else {
+            throw AuthError.invalidCallbackURL
+        }
+
+        guard let keyData = oauthState.ephemeralDPoPKey else { throw AuthError.dpopKeyError }
+        let ephemeralKey = try P256.Signing.PrivateKey(rawRepresentation: keyData)
+
+        try await storage.deleteOAuthState(for: stateToken)
+
+        guard let pdsURL = oauthState.targetPDSURL else { throw AuthError.invalidOAuthConfiguration }
+        let authServerURL = try await core.resolveAuthServer(for: pdsURL)
+        let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+
+        let tokenResponse = try await exchangeCodeForTokens(
+            code: code,
+            codeVerifier: oauthState.codeVerifier,
+            tokenEndpoint: metadata.tokenEndpoint,
+            authServerURL: authServerURL,
+            ephemeralKey: ephemeralKey,
+            initialNonce: oauthState.parResponseNonce,
+            resourceURL: pdsURL
+        )
+
+        guard let did = tokenResponse.sub else { throw AuthError.invalidResponse }
+
+        // Resolve real PDS
+        let didResolver = await core.didResolver
+        let (handle, actualPDS) = try await didResolver.resolveDIDToHandleAndPDSURL(did: did)
+
+        // Persist DPoP Key
+        try await storage.saveDPoPKey(ephemeralKey, for: did)
+
+        // Create Session
+        let session = Session(
+            accessToken: tokenResponse.accessToken,
+            refreshToken: tokenResponse.refreshToken,
+            createdAt: Date(),
+            expiresIn: TimeInterval(tokenResponse.expiresIn),
+            tokenType: .dpop,
+            did: did
+        )
+
+        // Create/Update Account
+        let account = Account(
+            did: did,
+            handle: handle ?? oauthState.initialIdentifier,
+            pdsURL: actualPDS,
+            protectedResourceMetadata: nil,
+            authorizationServerMetadata: metadata,
+            bskyAppViewDID: oauthState.bskyAppViewDID ?? "",
+            bskyChatDID: oauthState.bskyChatDID ?? ""
+        )
+
+        try await storage.saveAccountAndSession(account, session: session, for: did)
+        let accountManager = await core.accountManager
+        try await accountManager.updateAccountFromStorage(did: did)
+        try await accountManager.setCurrentAccount(did: did)
+        let networkService = await core.networkService
+        await networkService.setBaseURL(actualPDS)
+
+        return (did: did, handle: account.handle, pdsURL: actualPDS)
+    }
+
+    func loginWithPassword(
+        identifier: String,
+        password: String,
+        bskyAppViewDID: String?,
+        bskyChatDID: String?
+    ) async throws -> (did: String, handle: String?, pdsURL: URL) {
+        throw AuthError.invalidOAuthConfiguration // PublicOAuthStrategy doesn't support password login
+    }
+
+    func logout() async throws {
+        let accountManager = await core.accountManager
+        guard let did = await accountManager.getCurrentAccount()?.did else { return }
+
+        let storage = await core.storage
+        // Revoke token if possible
+        if let session = try? await storage.getSession(for: did),
+           let refreshToken = session.refreshToken,
+           let account = await accountManager.getAccount(did: did),
+           let endpoint = account.authorizationServerMetadata?.revocationEndpoint
+        {
+            await core.revokeToken(refreshToken: refreshToken, endpoint: endpoint, did: did)
+        }
+
+        try await storage.deleteSession(for: did)
+        try await storage.deleteDPoPKey(for: did)
+        try await storage.saveDPoPNonces([:], for: did)
+
+        await accountManager.clearCurrentAccount()
+    }
+
+    func cancelOAuthFlow() async {
+        oauthStartTasks.values.forEach { $0.cancel() }
+        oauthStartTasks.removeAll()
+        oauthStartInProgress = false
+    }
+
+    func tokensExist() async -> Bool {
+        await core.tokensExist()
+    }
+
+    func setProgressDelegate(_ delegate: AuthProgressDelegate?) async {
+        progressDelegate = delegate
+    }
+
+    func setFailureDelegate(_ delegate: AuthFailureDelegate?) async {
+        failureDelegate = delegate
+    }
+
+    func attemptRecoveryFromServerFailures(for did: String?) async throws {
+        var targetDID = did
+        if targetDID == nil {
+            targetDID = await core.accountManager.getCurrentAccount()?.did
+        }
+        guard let did = targetDID else { return }
+        await core.refreshCircuitBreaker.reset(for: did)
+        _ = try await refreshTokenIfNeeded(forceRefresh: true)
+    }
+
+    // MARK: - AuthenticationProvider
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        try await core.prepareAuthenticatedRequest(request)
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        try await core.prepareAuthenticatedRequestWithContext(request)
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        await ensureRefreshClosure()
+        return try await core.refreshTokenIfNeeded()
+    }
+
+    func refreshTokenIfNeeded(forceRefresh: Bool) async throws -> TokenRefreshResult {
+        await ensureRefreshClosure()
+        return try await core.refreshTokenIfNeeded(forceRefresh: forceRefresh)
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        guard response.statusCode == 401 else { return (data, response) }
+
+        let result = try await refreshTokenIfNeeded(forceRefresh: true)
+
+        switch result {
+        case .refreshedSuccessfully:
+            let (newReq, _) = try await core.prepareAuthenticatedRequestWithContext(request)
+            let networkService = await core.networkService
+            let result = try await networkService.request(newReq)
+            guard let http = result.1 as? HTTPURLResponse else { throw AuthError.invalidResponse }
+            return (result.0, http)
+        default:
+            throw AuthError.tokenRefreshFailed
+        }
+    }
+
+    func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
+        await core.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
+    }
+
+    // MARK: - Private Helpers (OAuth Flow)
+
+    private var refreshClosureSet = false
+
+    private func ensureRefreshClosure() async {
+        if !refreshClosureSet {
+            refreshClosureSet = true
+            await setupRefreshClosure()
+        }
+    }
+
+    private func _startOAuthFlowImpl(identifier: String?, bskyAppViewDID: String?, bskyChatDID: String?) async throws -> URL {
+        if oauthStartInProgress {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        oauthStartInProgress = true
+        defer { oauthStartInProgress = false }
+
+        let didResolver = await core.didResolver
+        let pdsURL: URL
+        if let identifier {
+            await emitProgress(.resolvingHandle(identifier))
+            let did = try await didResolver.resolveHandleToDID(handle: identifier)
+            pdsURL = try await didResolver.resolveDIDToPDSURL(did: did)
+        } else {
+            pdsURL = URL(string: "https://bsky.social")!
+        }
+
+        await emitProgress(.fetchingMetadata(url: pdsURL.absoluteString))
+        let authServerURL = try await core.resolveAuthServer(for: pdsURL)
+        let metadata = try await core.fetchAuthorizationServerMetadata(authServerURL: authServerURL)
+
+        await emitProgress(.generatingParameters)
+        let codeVerifier = await core.generateCodeVerifier()
+        let codeChallenge = await core.generateCodeChallenge(from: codeVerifier)
+        let stateToken = UUID().uuidString
+        let ephemeralKey = P256.Signing.PrivateKey()
+
+        let oauthConfig = await core.oauthConfig
+        let (requestURI, parNonce) = try await core.pushAuthorizationRequest(
+            codeChallenge: codeChallenge,
+            identifier: identifier,
+            endpoint: metadata.pushedAuthorizationRequestEndpoint,
+            authServerURL: authServerURL,
+            state: stateToken,
+            ephemeralKeyForFlow: ephemeralKey
+        )
+
+        let oauthState = OAuthState(
+            stateToken: stateToken,
+            codeVerifier: codeVerifier,
+            createdAt: Date(),
+            initialIdentifier: identifier,
+            targetPDSURL: pdsURL,
+            ephemeralDPoPKey: ephemeralKey.rawRepresentation,
+            parResponseNonce: parNonce,
+            bskyAppViewDID: bskyAppViewDID,
+            bskyChatDID: bskyChatDID
+        )
+        let storage = await core.storage
+        try await storage.saveOAuthState(oauthState)
+
+        guard var components = URLComponents(string: metadata.authorizationEndpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+        components.queryItems = [
+            URLQueryItem(name: "request_uri", value: requestURI),
+            URLQueryItem(name: "client_id", value: oauthConfig.clientId),
+            URLQueryItem(name: "redirect_uri", value: oauthConfig.redirectUri),
+        ]
+
+        guard let url = components.url else { throw AuthError.authorizationFailed }
+        return url
+    }
+
+    // MARK: - Token Exchange (Strategy-Specific)
+
+    private func exchangeCodeForTokens(
+        code: String,
+        codeVerifier: String,
+        tokenEndpoint: String,
+        authServerURL: URL,
+        ephemeralKey: P256.Signing.PrivateKey?,
+        initialNonce: String?,
+        resourceURL: URL?
+    ) async throws -> TokenResponse {
+        guard let url = URL(string: tokenEndpoint) else {
+            throw AuthError.invalidOAuthConfiguration
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30.0
+
+        let oauthConfig = await core.oauthConfig
+        var params: [String: String] = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": oauthConfig.redirectUri,
+            "client_id": oauthConfig.clientId,
+            "code_verifier": codeVerifier,
+        ]
+        if let resourceURL {
+            params["resource"] = resourceURL.absoluteString
+        }
+        request.httpBody = await core.encodeFormData(params)
+
+        if let key = ephemeralKey {
+            return try await sendTokenRequestWithEphemeralKey(
+                request: request,
+                tokenEndpoint: tokenEndpoint,
+                code: code,
+                codeVerifier: codeVerifier,
+                key: key,
+                nonce: initialNonce
+            )
+        } else {
+            // Fallback without DPoP (shouldn't happen in normal flow)
+            let networkService = await core.networkService
+            let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
+            guard let httpResponse = urlResponse as? HTTPURLResponse,
+                  (200 ..< 300).contains(httpResponse.statusCode)
+            else {
+                throw AuthError.tokenRefreshFailed
+            }
+            return try JSONDecoder().decode(TokenResponse.self, from: data)
+        }
+    }
+
+    private func sendTokenRequestWithEphemeralKey(
+        request baseRequest: URLRequest,
+        tokenEndpoint: String,
+        code: String,
+        codeVerifier: String,
+        key: P256.Signing.PrivateKey,
+        nonce: String?
+    ) async throws -> TokenResponse {
+        var request = baseRequest
+        request.timeoutInterval = 30.0
+
+        let dpopProof = try await core.createDPoPProof(
             for: "POST",
             url: tokenEndpoint,
             type: .tokenRequest,
             did: nil,
             ephemeralKey: key,
-            nonce: receivedNonce
-          )
-
-          var retryRequest = baseRequest
-          retryRequest.setValue(newDpopProof, forHTTPHeaderField: "DPoP")
-
-          let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
-          guard let retryHttpResponse = retryResponse as? HTTPURLResponse,
-                (200 ..< 300).contains(retryHttpResponse.statusCode)
-          else {
-            throw AuthError.tokenRefreshFailed
-          }
-          return try JSONDecoder().decode(TokenResponse.self, from: retryData)
-        } else {
-          throw AuthError.invalidCredentials
-        }
-      } else {
-        throw AuthError.tokenRefreshFailed
-      }
-    } catch let error as NetworkError {
-      throw AuthError.networkError(error)
-    } catch let error as AuthError {
-      throw error
-    } catch {
-      throw AuthError.tokenRefreshFailed
-    }
-  }
-
-  // MARK: - Token Refresh (Strategy-Specific)
-
-  private func performActualRefresh(for account: Account, session: Session) async throws -> TokenRefreshResult {
-    let data: Data
-    let response: HTTPURLResponse
-    do {
-      (data, response) = try await performTokenRefresh(for: account.did, session: session)
-    } catch let error as NetworkError {
-      // Transport never reached a definitive answer: the refresh token may still be valid.
-      await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .network)
-      throw AuthError.networkError(error)
-    }
-
-    if (200 ..< 300).contains(response.statusCode) {
-      let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
-      let newSession = Session(
-        accessToken: tokenResponse.accessToken,
-        refreshToken: tokenResponse.refreshToken,
-        createdAt: Date(),
-        expiresIn: TimeInterval(tokenResponse.expiresIn),
-        tokenType: session.tokenType,
-        did: account.did
-      )
-      // The server has rotated the refresh token; persistence failures are handled
-      // inside (retry + pending key + in-memory) and must not fail the refresh.
-      await core.persistRefreshedSession(newSession, for: account)
-      await core.refreshCircuitBreaker.recordSuccess(for: account.did)
-      return .refreshedSuccessfully
-    }
-
-    // Distinguish a definitive rejection (token consumed/revoked — never retry it)
-    // from transient server trouble (safe to retry with the same token).
-    if response.statusCode == 400 || response.statusCode == 401,
-       let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-       errorResponse.error == "invalid_grant"
-    {
-      LogManager.logError(
-        "Token refresh definitively rejected (invalid_grant) for DID: \(LogManager.logDID(account.did))"
-      )
-      await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .invalidGrant)
-      throw AuthError.invalidCredentials
-    }
-
-    let kind: RefreshCircuitBreaker.RefreshFailureKind = (500 ..< 600).contains(response.statusCode) ? .server : .other
-    await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: kind)
-    throw AuthError.tokenRefreshFailed
-  }
-
-  private func performTokenRefresh(for did: String, session: Session) async throws -> (Data, HTTPURLResponse) {
-    let accountManager = await core.accountManager
-    guard let account = await accountManager.getAccount(did: did),
-          let metadata = account.authorizationServerMetadata,
-          let refreshToken = session.refreshToken
-    else {
-      throw AuthError.tokenRefreshFailed
-    }
-
-    guard let endpointURL = URL(string: metadata.tokenEndpoint) else {
-      throw AuthError.tokenRefreshFailed
-    }
-
-    var request = URLRequest(url: endpointURL)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-    request.timeoutInterval = 30.0
-
-    let oauthConfig = await core.oauthConfig
-    let params = [
-      "grant_type": "refresh_token",
-      "refresh_token": refreshToken,
-      "client_id": oauthConfig.clientId,
-    ]
-    request.httpBody = await core.encodeFormData(params)
-
-    let proof = try await core.createDPoPProof(
-      for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
-    )
-    request.setValue(proof, forHTTPHeaderField: "DPoP")
-
-    let networkService = await core.networkService
-    let (data, response) = try await networkService.request(request, skipTokenRefresh: true)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw AuthError.invalidResponse
-    }
-
-    // Handle nonce mismatch with retry
-    if httpResponse.statusCode == 400 {
-      if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
-         errorResponse.error == "use_dpop_nonce",
-         let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
-      {
-        // Update nonce and retry
-        if let domain = endpointURL.host?.lowercased() {
-          await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
-        }
-
-        let retryProof = try await core.createDPoPProof(
-          for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+            nonce: nonce
         )
-        var retryRequest = request
-        retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
+        request.setValue(dpopProof, forHTTPHeaderField: "DPoP")
 
-        let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
-        guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
-          throw AuthError.invalidResponse
+        do {
+            let networkService = await core.networkService
+            let (data, urlResponse) = try await networkService.request(request, skipTokenRefresh: true)
+
+            guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                throw AuthError.invalidResponse
+            }
+
+            if (200 ..< 300).contains(httpResponse.statusCode) {
+                return try JSONDecoder().decode(TokenResponse.self, from: data)
+            } else if httpResponse.statusCode == 400 && nonce == nil {
+                // Handle use_dpop_nonce error
+                let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
+                var isNonceError = false
+                if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+                   errorResponse.error == "use_dpop_nonce"
+                {
+                    isNonceError = true
+                }
+
+                if isNonceError, let receivedNonce = dpopNonceHeader {
+                    let newDpopProof = try await core.createDPoPProof(
+                        for: "POST",
+                        url: tokenEndpoint,
+                        type: .tokenRequest,
+                        did: nil,
+                        ephemeralKey: key,
+                        nonce: receivedNonce
+                    )
+
+                    var retryRequest = baseRequest
+                    retryRequest.setValue(newDpopProof, forHTTPHeaderField: "DPoP")
+
+                    let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
+                    guard let retryHttpResponse = retryResponse as? HTTPURLResponse,
+                          (200 ..< 300).contains(retryHttpResponse.statusCode)
+                    else {
+                        throw AuthError.tokenRefreshFailed
+                    }
+                    return try JSONDecoder().decode(TokenResponse.self, from: retryData)
+                } else {
+                    throw AuthError.invalidCredentials
+                }
+            } else {
+                throw AuthError.tokenRefreshFailed
+            }
+        } catch let error as NetworkError {
+            throw AuthError.networkError(error)
+        } catch let error as AuthError {
+            throw error
+        } catch {
+            throw AuthError.tokenRefreshFailed
         }
-        return (retryData, retryHttpResponse)
-      }
     }
 
-    return (data, httpResponse)
-  }
+    // MARK: - Token Refresh (Strategy-Specific)
 
-  // MARK: - Progress Helpers
+    private func performActualRefresh(for account: Account, session: Session) async throws -> TokenRefreshResult {
+        let data: Data
+        let response: HTTPURLResponse
+        do {
+            (data, response) = try await performTokenRefresh(for: account.did, session: session)
+        } catch let error as NetworkError {
+            // Transport never reached a definitive answer: the refresh token may still be valid.
+            await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .network)
+            throw AuthError.networkError(error)
+        }
 
-  private func emitProgress(_ event: AuthProgressEvent) async {
-    await progressDelegate?.authenticationProgress(event)
-  }
+        if (200 ..< 300).contains(response.statusCode) {
+            let tokenResponse = try JSONDecoder().decode(TokenResponse.self, from: data)
+            let newSession = Session(
+                accessToken: tokenResponse.accessToken,
+                refreshToken: tokenResponse.refreshToken,
+                createdAt: Date(),
+                expiresIn: TimeInterval(tokenResponse.expiresIn),
+                tokenType: session.tokenType,
+                did: account.did
+            )
+            // The server has rotated the refresh token; persistence failures are handled
+            // inside (retry + pending key + in-memory) and must not fail the refresh.
+            await core.persistRefreshedSession(newSession, for: account)
+            await core.refreshCircuitBreaker.recordSuccess(for: account.did)
+            return .refreshedSuccessfully
+        }
+
+        // Distinguish a definitive rejection (token consumed/revoked — never retry it)
+        // from transient server trouble (safe to retry with the same token).
+        if response.statusCode == 400 || response.statusCode == 401,
+           let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+           errorResponse.error == "invalid_grant"
+        {
+            LogManager.logError(
+                "Token refresh definitively rejected (invalid_grant) for DID: \(LogManager.logDID(account.did))"
+            )
+            await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: .invalidGrant)
+            throw AuthError.invalidCredentials
+        }
+
+        let kind: RefreshCircuitBreaker.RefreshFailureKind = (500 ..< 600).contains(response.statusCode) ? .server : .other
+        await core.refreshCircuitBreaker.recordFailure(for: account.did, kind: kind)
+        throw AuthError.tokenRefreshFailed
+    }
+
+    private func performTokenRefresh(for did: String, session: Session) async throws -> (Data, HTTPURLResponse) {
+        let accountManager = await core.accountManager
+        guard let account = await accountManager.getAccount(did: did),
+              let metadata = account.authorizationServerMetadata,
+              let refreshToken = session.refreshToken
+        else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        guard let endpointURL = URL(string: metadata.tokenEndpoint) else {
+            throw AuthError.tokenRefreshFailed
+        }
+
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30.0
+
+        let oauthConfig = await core.oauthConfig
+        let params = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": oauthConfig.clientId,
+        ]
+        request.httpBody = await core.encodeFormData(params)
+
+        let proof = try await core.createDPoPProof(
+            for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+        )
+        request.setValue(proof, forHTTPHeaderField: "DPoP")
+
+        let networkService = await core.networkService
+        let (data, response) = try await networkService.request(request, skipTokenRefresh: true)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+
+        // Handle nonce mismatch with retry
+        if httpResponse.statusCode == 400 {
+            if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
+               errorResponse.error == "use_dpop_nonce",
+               let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
+            {
+                // Update nonce and retry
+                if let domain = endpointURL.host?.lowercased() {
+                    await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                }
+
+                let retryProof = try await core.createDPoPProof(
+                    for: "POST", url: metadata.tokenEndpoint, type: .tokenRefresh, did: did
+                )
+                var retryRequest = request
+                retryRequest.setValue(retryProof, forHTTPHeaderField: "DPoP")
+
+                let (retryData, retryResponse) = try await networkService.request(retryRequest, skipTokenRefresh: true)
+                guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+                    throw AuthError.invalidResponse
+                }
+                return (retryData, retryHttpResponse)
+            }
+        }
+
+        return (data, httpResponse)
+    }
+
+    // MARK: - Progress Helpers
+
+    private func emitProgress(_ event: AuthProgressEvent) async {
+        await progressDelegate?.authenticationProgress(event)
+    }
 }

--- a/Sources/Petrel/Core/Utils/RichText.swift
+++ b/Sources/Petrel/Core/Utils/RichText.swift
@@ -98,74 +98,74 @@ public extension String {
             RichTextAttributes.self
         }
     }
-
-    // MARK: AttributedString to facets
-
-    public extension AttributedString {
-        func toFacets() throws -> [AppBskyRichtextFacet]? {
-            let fullString = String(characters[...])
-
-            // Collect raw run data: (byteStart, byteEnd, urlString)
-            var rawRuns: [(byteStart: Int, byteEnd: Int, urlString: String)] = []
-
-            for run in runs {
-                let range = run.range
-                guard
-                    let lowerBound = String.Index(range.lowerBound, within: fullString),
-                    let upperBound = String.Index(range.upperBound, within: fullString),
-                    lowerBound < upperBound,
-                    let url = run.link
-                else {
-                    continue
-                }
-
-                let byteStart = fullString[..<lowerBound].utf8.count
-                let byteEnd = byteStart + fullString[lowerBound ..< upperBound].utf8.count
-                rawRuns.append((byteStart, byteEnd, url.absoluteString))
-            }
-
-            // Sort by byte position
-            rawRuns.sort { $0.byteStart < $1.byteStart }
-
-            // Merge adjacent runs with the same URL to avoid fragmented facets
-            var mergedRuns: [(byteStart: Int, byteEnd: Int, urlString: String)] = []
-            for run in rawRuns {
-                if let last = mergedRuns.last,
-                   last.urlString == run.urlString,
-                   last.byteEnd == run.byteStart
-                {
-                    // Extend the previous run
-                    mergedRuns[mergedRuns.count - 1].byteEnd = run.byteEnd
-                } else {
-                    mergedRuns.append(run)
-                }
-            }
-
-            // Build facets from merged runs
-            var facets: [AppBskyRichtextFacet] = []
-            for run in mergedRuns {
-                var features: [AppBskyRichtextFacet.AppBskyRichtextFacetFeaturesUnion] = []
-                let urlString = run.urlString
-
-                if urlString.starts(with: "mention://") {
-                    let encodedDID = String(urlString.dropFirst("mention://".count))
-                    let did = encodedDID.removingPercentEncoding ?? encodedDID
-                    try features.append(.appBskyRichtextFacetMention(AppBskyRichtextFacet.Mention(did: DID(didString: did))))
-                } else if urlString.starts(with: "tag://") {
-                    let tag = String(urlString.dropFirst("tag://".count))
-                    features.append(.appBskyRichtextFacetTag(AppBskyRichtextFacet.Tag(tag: tag)))
-                } else {
-                    features.append(
-                        .appBskyRichtextFacetLink(AppBskyRichtextFacet.Link(uri: URI(uriString: urlString)))
-                    )
-                }
-
-                let byteSlice = AppBskyRichtextFacet.ByteSlice(byteStart: run.byteStart, byteEnd: run.byteEnd)
-                let facet = AppBskyRichtextFacet(index: byteSlice, features: features)
-                facets.append(facet)
-            }
-
-            return facets.isEmpty ? nil : facets
-        }
-    }
 #endif
+
+// MARK: AttributedString to facets
+
+public extension AttributedString {
+    func toFacets() throws -> [AppBskyRichtextFacet]? {
+        let fullString = String(characters[...])
+
+        // Collect raw run data: (byteStart, byteEnd, urlString)
+        var rawRuns: [(byteStart: Int, byteEnd: Int, urlString: String)] = []
+
+        for run in runs {
+            let range = run.range
+            guard
+                let lowerBound = String.Index(range.lowerBound, within: fullString),
+                let upperBound = String.Index(range.upperBound, within: fullString),
+                lowerBound < upperBound,
+                let url = run.link
+            else {
+                continue
+            }
+
+            let byteStart = fullString[..<lowerBound].utf8.count
+            let byteEnd = byteStart + fullString[lowerBound ..< upperBound].utf8.count
+            rawRuns.append((byteStart, byteEnd, url.absoluteString))
+        }
+
+        // Sort by byte position
+        rawRuns.sort { $0.byteStart < $1.byteStart }
+
+        // Merge adjacent runs with the same URL to avoid fragmented facets
+        var mergedRuns: [(byteStart: Int, byteEnd: Int, urlString: String)] = []
+        for run in rawRuns {
+            if let last = mergedRuns.last,
+               last.urlString == run.urlString,
+               last.byteEnd == run.byteStart
+            {
+                // Extend the previous run
+                mergedRuns[mergedRuns.count - 1].byteEnd = run.byteEnd
+            } else {
+                mergedRuns.append(run)
+            }
+        }
+
+        // Build facets from merged runs
+        var facets: [AppBskyRichtextFacet] = []
+        for run in mergedRuns {
+            var features: [AppBskyRichtextFacet.AppBskyRichtextFacetFeaturesUnion] = []
+            let urlString = run.urlString
+
+            if urlString.starts(with: "mention://") {
+                let encodedDID = String(urlString.dropFirst("mention://".count))
+                let did = encodedDID.removingPercentEncoding ?? encodedDID
+                try features.append(.appBskyRichtextFacetMention(AppBskyRichtextFacet.Mention(did: DID(didString: did))))
+            } else if urlString.starts(with: "tag://") {
+                let tag = String(urlString.dropFirst("tag://".count))
+                features.append(.appBskyRichtextFacetTag(AppBskyRichtextFacet.Tag(tag: tag)))
+            } else {
+                features.append(
+                    .appBskyRichtextFacetLink(AppBskyRichtextFacet.Link(uri: URI(uriString: urlString)))
+                )
+            }
+
+            let byteSlice = AppBskyRichtextFacet.ByteSlice(byteStart: run.byteStart, byteEnd: run.byteEnd)
+            let facet = AppBskyRichtextFacet(index: byteSlice, features: features)
+            facets.append(facet)
+        }
+
+        return facets.isEmpty ? nil : facets
+    }
+}

--- a/Sources/Petrel/Network/HardenedURLSessionDelegate.swift
+++ b/Sources/Petrel/Network/HardenedURLSessionDelegate.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(Security)
+    import Security
+#endif
 #if canImport(FoundationNetworking)
     import FoundationNetworking
 #endif
@@ -32,7 +35,7 @@ final class HardenedURLSessionDelegate: NSObject, URLSessionDelegate, URLSession
         }
     }
 
-    private struct TaskContext: Sendable {
+    private struct TaskContext {
         var redirectCount = 0
         var receivedData = Data()
     }
@@ -105,54 +108,58 @@ final class HardenedURLSessionDelegate: NSObject, URLSessionDelegate, URLSession
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        Task {
-            guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-                  let serverTrust = challenge.protectionSpace.serverTrust
-            else {
-                LogManager.logError("Authentication challenge is not for server trust.")
-                completionHandler(.performDefaultHandling, nil)
-                return
+        #if canImport(Security)
+            Task {
+                guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+                      let serverTrust = challenge.protectionSpace.serverTrust
+                else {
+                    LogManager.logError("Authentication challenge is not for server trust.")
+                    completionHandler(.performDefaultHandling, nil)
+                    return
+                }
+
+                // Enforce HTTPS Scheme
+                guard challenge.protectionSpace.protocol == "https" else {
+                    LogManager.logError("Connection is not over HTTPS. Protocol: \(challenge.protectionSpace.protocol ?? "nil")")
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                    return
+                }
+
+                // Optional: Restrict to allowed hostnames (uncomment and customize if needed)
+                /*
+                 let allowedHostnames: Set<String> = [
+                     "bsky.social",
+                     // Add other pre-trusted hostnames here
+                 ]
+                 let host = challenge.protectionSpace.host.lowercased()
+                 if !allowedHostnames.contains(host) {
+                     LogManager.logError("Host \(host) is not in the list of allowed hostnames.")
+                     completionHandler(.cancelAuthenticationChallenge, nil)
+                     return
+                 }
+                 */
+
+                // Evaluate server trust
+                let policy = SecPolicyCreateSSL(true, challenge.protectionSpace.host as CFString)
+                SecTrustSetPolicies(serverTrust, policy)
+
+                var error: CFError?
+                let isServerTrustValid = SecTrustEvaluateWithError(serverTrust, &error)
+
+                if isServerTrustValid {
+                    // Proceed with the connection
+                    let credential = URLCredential(trust: serverTrust)
+                    LogManager.logInfo("Server trust evaluation succeeded for host: \(challenge.protectionSpace.host)")
+                    completionHandler(.useCredential, credential)
+                } else {
+                    // Server trust evaluation failed
+                    LogManager.logError("Server trust evaluation failed for host: \(challenge.protectionSpace.host). Error: \(error?.localizedDescription ?? "Unknown error")")
+                    completionHandler(.cancelAuthenticationChallenge, nil)
+                }
             }
-
-            // Enforce HTTPS Scheme
-            guard challenge.protectionSpace.protocol == "https" else {
-                LogManager.logError("Connection is not over HTTPS. Protocol: \(challenge.protectionSpace.protocol ?? "nil")")
-                completionHandler(.cancelAuthenticationChallenge, nil)
-                return
-            }
-
-            // Optional: Restrict to allowed hostnames (uncomment and customize if needed)
-            /*
-             let allowedHostnames: Set<String> = [
-                 "bsky.social",
-                 // Add other pre-trusted hostnames here
-             ]
-             let host = challenge.protectionSpace.host.lowercased()
-             if !allowedHostnames.contains(host) {
-                 LogManager.logError("Host \(host) is not in the list of allowed hostnames.")
-                 completionHandler(.cancelAuthenticationChallenge, nil)
-                 return
-             }
-             */
-
-            // Evaluate server trust
-            let policy = SecPolicyCreateSSL(true, challenge.protectionSpace.host as CFString)
-            SecTrustSetPolicies(serverTrust, policy)
-
-            var error: CFError?
-            let isServerTrustValid = SecTrustEvaluateWithError(serverTrust, &error)
-
-            if isServerTrustValid {
-                // Proceed with the connection
-                let credential = URLCredential(trust: serverTrust)
-                LogManager.logInfo("Server trust evaluation succeeded for host: \(challenge.protectionSpace.host)")
-                completionHandler(.useCredential, credential)
-            } else {
-                // Server trust evaluation failed
-                LogManager.logError("Server trust evaluation failed for host: \(challenge.protectionSpace.host). Error: \(error?.localizedDescription ?? "Unknown error")")
-                completionHandler(.cancelAuthenticationChallenge, nil)
-            }
-        }
+        #else
+            completionHandler(.performDefaultHandling, nil)
+        #endif
     }
 
     // MARK: - URLSessionTaskDelegate

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -82,37 +82,37 @@ enum ContentDecoding {
         guard !data.isEmpty else { return data }
 
         #if canImport(Compression)
-        var outputSize = max(data.count * 10, 65536)
-        var outputData = Data(count: outputSize)
+            var outputSize = max(data.count * 10, 65536)
+            var outputData = Data(count: outputSize)
 
-        for _ in 0 ..< 5 {
-            let result = data.withUnsafeBytes { sourceBuffer -> Int in
-                guard let sourcePtr = sourceBuffer.baseAddress else { return 0 }
-                return outputData.withUnsafeMutableBytes { destBuffer -> Int in
-                    guard let destPtr = destBuffer.baseAddress else { return 0 }
-                    return compression_decode_buffer(
-                        destPtr.assumingMemoryBound(to: UInt8.self),
-                        outputSize,
-                        sourcePtr.assumingMemoryBound(to: UInt8.self),
-                        data.count,
-                        nil,
-                        COMPRESSION_BROTLI
-                    )
+            for _ in 0 ..< 5 {
+                let result = data.withUnsafeBytes { sourceBuffer -> Int in
+                    guard let sourcePtr = sourceBuffer.baseAddress else { return 0 }
+                    return outputData.withUnsafeMutableBytes { destBuffer -> Int in
+                        guard let destPtr = destBuffer.baseAddress else { return 0 }
+                        return compression_decode_buffer(
+                            destPtr.assumingMemoryBound(to: UInt8.self),
+                            outputSize,
+                            sourcePtr.assumingMemoryBound(to: UInt8.self),
+                            data.count,
+                            nil,
+                            COMPRESSION_BROTLI
+                        )
+                    }
+                }
+
+                if result > 0, result < outputSize {
+                    outputData.count = result
+                    return outputData
+                } else if result == outputSize {
+                    outputSize *= 2
+                    outputData = Data(count: outputSize)
+                } else {
+                    break
                 }
             }
 
-            if result > 0, result < outputSize {
-                outputData.count = result
-                return outputData
-            } else if result == outputSize {
-                outputSize *= 2
-                outputData = Data(count: outputSize)
-            } else {
-                break
-            }
-        }
-
-        return nil
+            return nil
         #else
             // FoundationNetworking is responsible for content decoding on
             // platforms where Apple's optional Compression framework is absent.
@@ -1737,16 +1737,14 @@ public actor NetworkService: NetworkServiceProtocol {
 
     private func resolveHostIPs(host: String) -> [String] {
         var results: [String] = []
-        var hints = addrinfo(
-            ai_flags: AI_ADDRCONFIG,
-            ai_family: AF_UNSPEC,
-            ai_socktype: SOCK_STREAM,
-            ai_protocol: 0,
-            ai_addrlen: 0,
-            ai_canonname: nil,
-            ai_addr: nil,
-            ai_next: nil
-        )
+        var hints = addrinfo()
+        hints.ai_flags = AI_ADDRCONFIG
+        hints.ai_family = AF_UNSPEC
+        #if os(Linux)
+            hints.ai_socktype = Int32(SOCK_STREAM.rawValue)
+        #else
+            hints.ai_socktype = SOCK_STREAM
+        #endif
         var res: UnsafeMutablePointer<addrinfo>? = nil
         let status = getaddrinfo(host, nil, &hints, &res)
         if status == 0, let head = res {

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -12,7 +12,9 @@ import Foundation
 #if canImport(Network)
     import Network
 #endif
-import Compression
+#if canImport(Compression)
+    import Compression
+#endif
 
 // MARK: - Content-Encoding Decompression
 
@@ -79,6 +81,7 @@ enum ContentDecoding {
     private static func decompressBrotli(_ data: Data) -> Data? {
         guard !data.isEmpty else { return data }
 
+        #if canImport(Compression)
         var outputSize = max(data.count * 10, 65536)
         var outputData = Data(count: outputSize)
 
@@ -110,6 +113,11 @@ enum ContentDecoding {
         }
 
         return nil
+        #else
+            // FoundationNetworking is responsible for content decoding on
+            // platforms where Apple's optional Compression framework is absent.
+            return nil
+        #endif
     }
 }
 

--- a/Sources/Petrel/Storage/KeychainStorage.swift
+++ b/Sources/Petrel/Storage/KeychainStorage.swift
@@ -811,6 +811,12 @@ public actor KeychainStorage {
         }
     }
 
+    /// Checks whether a DPoP key exists without moving private key material
+    /// across the storage actor boundary.
+    public func containsDPoPKey(for did: String) async throws -> Bool {
+        try await getDPoPKey(for: did) != nil
+    }
+
     /// Deletes a DPoP key from the keychain.
     /// - Parameter did: The DID associated with the key to delete
     public func deleteDPoPKey(for did: String) async throws {

--- a/Tests/PetrelTests/CIDTests.swift
+++ b/Tests/PetrelTests/CIDTests.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 @testable import Petrel
 import SwiftCBOR

--- a/Tests/PetrelTests/KeychainStorageRaceConditionTests.swift
+++ b/Tests/PetrelTests/KeychainStorageRaceConditionTests.swift
@@ -5,7 +5,6 @@
 //  Created by Claude on September 20, 2025.
 //
 
-import CryptoKit
 @testable import Petrel
 import XCTest
 

--- a/Tests/PetrelTests/LogManagerTests.swift
+++ b/Tests/PetrelTests/LogManagerTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 @testable import Petrel
 import Testing
 

--- a/generator/cycle_detector.py
+++ b/generator/cycle_detector.py
@@ -112,8 +112,12 @@ class CycleDetector:
         """Register query/procedure output unions with 'Output' prefix"""
         swift_base = convert_to_camel_case(lexicon_id)
         properties = output_schema.get('properties', {})
+        if not isinstance(properties, dict):
+            return
 
         for prop_name, prop_schema in properties.items():
+            if not isinstance(prop_schema, dict):
+                continue
             # Handle union properties in output
             if prop_schema.get('type') == 'union':
                 # Output unions use "Output" as the struct name prefix

--- a/generator/kotlin_code_generator.py
+++ b/generator/kotlin_code_generator.py
@@ -141,6 +141,19 @@ class KotlinCodeGenerator(BaseCodeGenerator):
     def generate_lex_definitions(self) -> str:
         """Generate nested type definitions."""
         definitions = []
+        strict_documentation_defs = set()
+        output = self.main_def.get('output')
+        if isinstance(output, dict):
+            schema = output.get('schema')
+            if isinstance(schema, dict):
+                properties = schema.get('properties')
+                if isinstance(properties, dict):
+                    for prop in properties.values():
+                        if not isinstance(prop, dict) or not prop.get('x-security-strict-decode'):
+                            continue
+                        ref = prop.get('ref')
+                        if isinstance(ref, str) and ref.startswith('#'):
+                            strict_documentation_defs.add(ref[1:])
 
         for name, def_schema in self.defs.items():
             if name == 'main':
@@ -160,7 +173,8 @@ class KotlinCodeGenerator(BaseCodeGenerator):
                     'name': class_name,
                     'type': 'data_class',
                     'properties': properties,
-                    'description': def_schema.get('description', '')
+                    'description': def_schema.get('description', ''),
+                    'security_strict_documentation': name in strict_documentation_defs,
                 })
 
             elif def_type == 'string' and 'knownValues' in def_schema:

--- a/generator/main.py
+++ b/generator/main.py
@@ -67,8 +67,9 @@ async def load_lexicons(dirs, exclude_namespaces, cycle_detector, skip_ids=()):
                 # Also register query/procedure output unions
                 main_def = defs.get('main', {})
                 if main_def.get('type') in ['query', 'procedure']:
-                    output_schema = main_def.get('output', {}).get('schema', {})
-                    if output_schema.get('type') == 'object':
+                    output = main_def.get('output')
+                    output_schema = output.get('schema') if isinstance(output, dict) else None
+                    if isinstance(output_schema, dict) and output_schema.get('type') == 'object':
                         cycle_detector.add_output_type(lexicon_id, output_schema)
 
                 loaded.append((filepath, lexicon))

--- a/generator/swift_code_generator.py
+++ b/generator/swift_code_generator.py
@@ -64,6 +64,11 @@ class SwiftCodeGenerator:
             swift_type = self.type_converter.determine_swift_type(name, prop, required_fields, current_struct_name)
             description = prop.get('description', '')
             is_optional = name not in required_fields
+            strict_optional_decode = prop.get('x-security-strict-decode', False)
+            if strict_optional_decode and (not is_optional or prop.get('type') != 'ref'):
+                raise ValueError(
+                    f"x-security-strict-decode is supported only on optional ref properties: '{name}'"
+                )
 
             # Check if this property should be boxed to break a circular reference
             should_box = False
@@ -79,7 +84,8 @@ class SwiftCodeGenerator:
                 'type': swift_type,
                 'optional': is_optional,
                 'description': description,
-                'boxed': should_box
+                'boxed': should_box,
+                'strict_optional_decode': strict_optional_decode,
             })
         return swift_properties
 
@@ -124,14 +130,16 @@ class SwiftCodeGenerator:
 
         encoding = output_obj.get('encoding', '')
         output_schema = output_obj.get('schema', {})
-        for property_name, property_schema in output_schema.get('properties', {}).items():
-            if property_schema.get('type') != 'ref':
-                continue
-            ref = property_schema.get('ref', '')
-            if ref.startswith('#') and ref[1:] not in self.defs:
-                raise ValueError(
-                    f"output property '{property_name}' references missing local definition '{ref}'"
-                )
+        if not isinstance(output_schema, dict):
+            output_schema = {}
+        output_properties = output_schema.get('properties', {})
+        if not isinstance(output_properties, dict):
+            output_properties = {}
+        output_properties = {
+            name: schema for name, schema in output_properties.items()
+            if isinstance(schema, dict)
+        }
+        output_schema = {**output_schema, 'properties': output_properties}
 
         context = {
             'conformance': ": ATProtocolCodable" if encoding == "application/json" else "",
@@ -156,6 +164,32 @@ class SwiftCodeGenerator:
             context['properties'] = self.generate_properties(output_schema.get('properties', {}), output_schema.get('required', []), "Output")
 
         return self.template_manager.output_struct_template.render(**context)
+
+    def validate_output_local_refs(self) -> None:
+        """Reject references to missing local definitions in every output shape."""
+        output = self.main_def.get('output')
+        if not isinstance(output, dict):
+            return
+        schema = output.get('schema')
+        if not isinstance(schema, dict):
+            return
+
+        def validate(node: Any, path: str) -> None:
+            if not isinstance(node, dict):
+                return
+            if node.get('type') == 'ref':
+                ref = node.get('ref', '')
+                if isinstance(ref, str) and ref.startswith('#') and ref[1:] not in self.defs:
+                    raise ValueError(
+                        f"output {path} references missing local definition '{ref}'"
+                    )
+            properties = node.get('properties')
+            if isinstance(properties, dict):
+                for name, property_schema in properties.items():
+                    validate(property_schema, f"property '{name}'")
+            validate(node.get('items'), f"{path} array item")
+
+        validate(schema, "schema")
 
     def generate_errors_enum(self, errors: Optional[List[Dict[str, str]]]) -> str:
         if not errors:
@@ -281,6 +315,9 @@ class SwiftCodeGenerator:
                     self.enum_generator.generate_enum_for_union_array(current_struct_name, prop_name, refs)
 
     def convert(self) -> str:
+        # Security-bearing local output references must fail the generation
+        # command instead of being serialized into a traceback-shaped source file.
+        self.validate_output_local_refs()
         try:
             query_parameters = ""
             input_struct = ""

--- a/generator/swift_code_generator.py
+++ b/generator/swift_code_generator.py
@@ -124,6 +124,14 @@ class SwiftCodeGenerator:
 
         encoding = output_obj.get('encoding', '')
         output_schema = output_obj.get('schema', {})
+        for property_name, property_schema in output_schema.get('properties', {}).items():
+            if property_schema.get('type') != 'ref':
+                continue
+            ref = property_schema.get('ref', '')
+            if ref.startswith('#') and ref[1:] not in self.defs:
+                raise ValueError(
+                    f"output property '{property_name}' references missing local definition '{ref}'"
+                )
 
         context = {
             'conformance': ": ATProtocolCodable" if encoding == "application/json" else "",

--- a/generator/templates/kotlin/lexiconDefinitions.jinja
+++ b/generator/templates/kotlin/lexiconDefinitions.jinja
@@ -9,9 +9,17 @@
     {% if def.properties %}
     data class {{ def.name }}(
         {% for prop in def.properties %}
+        {% if def.security_strict_documentation %}
+        {% if prop.description %}
+        /** {{ prop.description }} */
+        {% endif %}
+        @SerialName("{{ prop.name }}")
+        val {{ prop.name | sanitizeKeyword }}: {{ prop.type }}{% if prop.optional %} = null{% endif %}{% if not loop.last %},{% endif %}{{ '\n' -}}
+        {% else %}
         {% if prop.description %}/** {{ prop.description }} */{% endif %}
         @SerialName("{{ prop.name }}")
         val {{ prop.name | sanitizeKeyword }}: {{ prop.type }}{% if prop.optional %} = null{% endif %}{% if not loop.last %},{% endif %}
+        {% endif %}
         {% endfor %}
     ) {
         companion object {

--- a/generator/templates/output.jinja
+++ b/generator/templates/output.jinja
@@ -36,6 +36,9 @@
             let container = try decoder.container(keyedBy: CodingKeys.self)
             {%- for prop in properties %}
             {% if prop.optional %}
+            {% if prop.strict_optional_decode %}
+            self.{{ prop.name }} = try container.decodeIfPresent({{ prop.type }}.self, forKey: .{{ prop.name }})
+            {% else %}
             do {
                 self.{{ prop.name }} = try container.decodeIfPresent({{ prop.type }}.self, forKey: .{{ prop.name }})
             } catch {
@@ -43,6 +46,7 @@
                 LogManager.logWarning("Decoding error for optional property '{{ prop.name }}' — degrading to nil: \(error)")
                 self.{{ prop.name }} = nil
             }
+            {% endif %}
             {% else %}
             self.{{ prop.name }} = try container.decode({{ prop.type }}.self, forKey: .{{ prop.name }})
             {% endif %}

--- a/generator/tests/test_swift_optional_local_ref_output.py
+++ b/generator/tests/test_swift_optional_local_ref_output.py
@@ -6,6 +6,7 @@ GENERATOR_DIR = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(GENERATOR_DIR))
 
 from swift_code_generator import SwiftCodeGenerator
+from kotlin_code_generator import KotlinCodeGenerator
 
 
 class SwiftOptionalLocalRefOutputTests(unittest.TestCase):
@@ -23,7 +24,11 @@ class SwiftOptionalLocalRefOutputTests(unittest.TestCase):
                             "required": ["success"],
                             "properties": {
                                 "success": {"type": "boolean"},
-                                "receipt": {"type": "ref", "ref": "#sequencerReceipt"},
+                                "receipt": {
+                                    "type": "ref",
+                                    "ref": "#sequencerReceipt",
+                                    "x-security-strict-decode": True,
+                                },
                             },
                         },
                     },
@@ -40,8 +45,49 @@ class SwiftOptionalLocalRefOutputTests(unittest.TestCase):
         self.assertIn("public struct SequencerReceipt", generated)
         self.assertIn("public let receipt: SequencerReceipt?", generated)
         self.assertIn("decodeIfPresent(SequencerReceipt.self, forKey: .receipt)", generated)
+        self.assertNotIn("property 'receipt' — degrading to nil", generated)
         self.assertIn("encodeIfPresent(receipt, forKey: .receipt)", generated)
         self.assertIn("case receipt", generated)
+
+    def test_kotlin_kdoc_is_narrowed_to_security_strict_referenced_definition(self):
+        lexicon = {
+            "lexicon": 1,
+            "id": "blue.catbird.test.receipt",
+            "defs": {
+                "main": {
+                    "type": "procedure",
+                    "output": {
+                        "encoding": "application/json",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "receipt": {
+                                    "type": "ref",
+                                    "ref": "#sequencerReceipt",
+                                    "x-security-strict-decode": True,
+                                }
+                            },
+                        },
+                    },
+                },
+                "sequencerReceipt": {
+                    "type": "object",
+                    "properties": {
+                        "epoch": {"type": "integer", "description": "Accepted epoch."}
+                    },
+                },
+                "ordinary": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string", "description": "Ordinary label."}
+                    },
+                },
+            },
+        }
+
+        generated = KotlinCodeGenerator(lexicon).convert()
+        self.assertIn("/** Accepted epoch. */\n        @SerialName", generated)
+        self.assertNotIn("        /** Ordinary label. */", generated)
 
     def test_missing_local_output_ref_fails_generation(self):
         lexicon = {
@@ -62,8 +108,67 @@ class SwiftOptionalLocalRefOutputTests(unittest.TestCase):
                 }
             },
         }
+        with self.assertRaisesRegex(ValueError, "references missing local definition"):
+            SwiftCodeGenerator(lexicon).convert()
+
+    def test_null_and_malformed_output_schema_do_not_crash_generation(self):
+        for schema in (None, "not-an-object"):
+            lexicon = {
+                "lexicon": 1,
+                "id": "blue.catbird.test.empty",
+                "defs": {
+                    "main": {
+                        "type": "procedure",
+                        "output": {"encoding": "application/json", "schema": schema},
+                    }
+                },
+            }
+            generated = SwiftCodeGenerator(lexicon).convert()
+            self.assertIn("public struct BlueCatbirdTestEmpty", generated)
+
+    def test_malformed_output_property_is_ignored(self):
+        lexicon = {
+            "lexicon": 1,
+            "id": "blue.catbird.test.empty",
+            "defs": {
+                "main": {
+                    "type": "procedure",
+                    "output": {
+                        "encoding": "application/json",
+                        "schema": {"type": "object", "properties": {"bad": None}},
+                    },
+                }
+            },
+        }
         generated = SwiftCodeGenerator(lexicon).convert()
-        self.assertIn("references missing local definition", generated)
+        self.assertIn("public struct BlueCatbirdTestEmpty", generated)
+
+    def test_missing_top_level_and_array_item_local_refs_fail_generation(self):
+        schemas = (
+            {"type": "ref", "ref": "#missing"},
+            {
+                "type": "object",
+                "properties": {
+                    "receipts": {
+                        "type": "array",
+                        "items": {"type": "ref", "ref": "#missing"},
+                    }
+                },
+            },
+        )
+        for schema in schemas:
+            lexicon = {
+                "lexicon": 1,
+                "id": "blue.catbird.test.receipt",
+                "defs": {
+                    "main": {
+                        "type": "procedure",
+                        "output": {"encoding": "application/json", "schema": schema},
+                    }
+                },
+            }
+            with self.assertRaisesRegex(ValueError, "references missing local definition"):
+                SwiftCodeGenerator(lexicon).convert()
 
 
 if __name__ == "__main__":

--- a/generator/tests/test_swift_optional_local_ref_output.py
+++ b/generator/tests/test_swift_optional_local_ref_output.py
@@ -1,0 +1,70 @@
+import pathlib
+import sys
+import unittest
+
+GENERATOR_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(GENERATOR_DIR))
+
+from swift_code_generator import SwiftCodeGenerator
+
+
+class SwiftOptionalLocalRefOutputTests(unittest.TestCase):
+    def test_optional_local_ref_emits_definition_and_output_codec(self):
+        lexicon = {
+            "lexicon": 1,
+            "id": "blue.catbird.test.receipt",
+            "defs": {
+                "main": {
+                    "type": "procedure",
+                    "output": {
+                        "encoding": "application/json",
+                        "schema": {
+                            "type": "object",
+                            "required": ["success"],
+                            "properties": {
+                                "success": {"type": "boolean"},
+                                "receipt": {"type": "ref", "ref": "#sequencerReceipt"},
+                            },
+                        },
+                    },
+                },
+                "sequencerReceipt": {
+                    "type": "object",
+                    "required": ["sequencerTerm"],
+                    "properties": {"sequencerTerm": {"type": "integer"}},
+                },
+            },
+        }
+
+        generated = SwiftCodeGenerator(lexicon).convert()
+        self.assertIn("public struct SequencerReceipt", generated)
+        self.assertIn("public let receipt: SequencerReceipt?", generated)
+        self.assertIn("decodeIfPresent(SequencerReceipt.self, forKey: .receipt)", generated)
+        self.assertIn("encodeIfPresent(receipt, forKey: .receipt)", generated)
+        self.assertIn("case receipt", generated)
+
+    def test_missing_local_output_ref_fails_generation(self):
+        lexicon = {
+            "lexicon": 1,
+            "id": "blue.catbird.test.receipt",
+            "defs": {
+                "main": {
+                    "type": "procedure",
+                    "output": {
+                        "encoding": "application/json",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "receipt": {"type": "ref", "ref": "#missing"}
+                            },
+                        },
+                    },
+                }
+            },
+        }
+        generated = SwiftCodeGenerator(lexicon).convert()
+        self.assertIn("references missing local definition", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add schema-driven strict decoding for security-bearing optional references. Absent/null remains optional; malformed present values throw. Also fail fast on missing local output refs and cover both behaviors with generator regressions. Independent security review: APPROVE as part of the Wave 1 receipt contract.