### PR TITLE
security: migrate Kotlin gateway OAuth to one-time exchange codes

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -23,4 +23,5 @@ jobs:
           java-version: 17
       - uses: gradle/actions/setup-gradle@v4
       - name: Build
-        run: ./gradlew -p kotlin build
+        working-directory: kotlin
+        run: ./gradlew build

--- a/generator/templates/kotlin/KotlinClientMain.jinja
+++ b/generator/templates/kotlin/KotlinClientMain.jinja
@@ -102,31 +102,14 @@ class ATProtoClient(val networkService: NetworkService) {
     }
 
     @Deprecated(
-        "Broken: parses did/handle from fragment but nest only sends session_id. " +
-            "Use ATProtoClient.configureGateway(...) + gatewayHandleCallback(url) which " +
-            "fetches canonical session info from GET /auth/session.",
+        "Disabled: URL-carried session credentials are unsafe. Use " +
+            "ATProtoClient.configureGateway(...) + gatewayHandleCallback(url).",
         ReplaceWith("gatewayHandleCallback(callbackUrl)"),
     )
     fun handleGatewayCallback(callbackUrl: String): GatewaySessionInfo {
-        val fragment = callbackUrl.substringAfter("#", "")
-        val params = fragment.split("&").associate { part ->
-            val (key, value) = part.split("=", limit = 2)
-            key to java.net.URLDecoder.decode(value, "UTF-8")
-        }
-
-        val sessionId = params["session_id"]
-            ?: throw IllegalArgumentException("Gateway callback missing session_id")
-
-        val session = GatewaySessionInfo(
-            sessionId = sessionId,
-            did = params["did"] ?: "",
-            handle = params["handle"]
+        throw UnsupportedOperationException(
+            "Legacy gateway callbacks are disabled; use the single-use exchange flow",
         )
-        gatewaySession = session
-        networkService.authenticatedDID = session.did
-        networkService.authorizationHeader = "Bearer $sessionId"
-        authMode = AuthMode.Gateway
-        return session
     }
 
     @Deprecated(

--- a/kotlin/src/main/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayStrategy.kt
+++ b/kotlin/src/main/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayStrategy.kt
@@ -9,18 +9,24 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.readRemaining
 import java.net.URI
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.logging.Logger
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.readByteArray
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -101,6 +107,7 @@ class ConfidentialGatewayStrategy(
     private val currentAccount: CurrentAccount,
     private val networkService: NetworkService,
     httpClient: HttpClient? = null,
+    private val requestTimeoutMillis: Long = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MILLIS,
 ) {
     private val logger: Logger = Logger.getLogger("ConfidentialGatewayStrategy")
 
@@ -219,36 +226,37 @@ class ConfidentialGatewayStrategy(
      */
     suspend fun logout() {
         logger.info("Gateway logout initiated")
-        val did = currentAccount.getCurrentDid()
-        if (did == null) {
-            logger.warning("No current account set, nothing to logout")
-            return
-        }
-        val session = storage.getSession(did)
-        if (session != null) {
-            val logoutUrl = composeGatewayUrl("/auth/logout")
-            try {
-                val response: HttpResponse = http.post(logoutUrl) {
-                    header("Authorization", "Bearer $session")
-                    header("Content-Type", "application/json")
-                }
-                if (response.status != HttpStatusCode.OK) {
-                    val body = runCatching { response.bodyAsText() }.getOrDefault("no body")
-                    logger.warning("Gateway logout non-200: ${response.status.value} $body")
-                }
-            } catch (t: Throwable) {
-                // Don't fail logout if gateway is unreachable.
-                logger.warning("Gateway logout request failed (continuing): ${t.message}")
+        val did = runCatching { currentAccount.getCurrentDid() }
+            .onFailure { logCleanupFailure("read current account", it) }
+            .getOrNull()
+        try {
+            val session = if (did != null) {
+                runCatching { storage.getSession(did) }
+                    .onFailure { logCleanupFailure("read gateway session", it) }
+                    .getOrNull()
+            } else {
+                logger.warning("No current account set; clearing any stale local credentials")
+                null
             }
-        } else {
-            logger.info("No gateway session for DID ${did.take(20)}…, skipping server logout")
-        }
-
-        mutex.withLock {
-            storage.deleteSession(did)
-            currentAccount.setCurrentDid(null)
-            networkService.authenticatedDID = null
-            networkService.authorizationHeader = null
+            if (session != null) {
+                val logoutUrl = composeGatewayUrl("/auth/logout")
+                try {
+                    val response: HttpResponse = http.post(logoutUrl) {
+                        header("Authorization", "Bearer $session")
+                        header("Content-Type", "application/json")
+                    }
+                    if (response.status != HttpStatusCode.OK) {
+                        logger.warning("Gateway logout returned HTTP ${response.status.value}")
+                    }
+                } catch (t: Throwable) {
+                    // Don't fail logout if gateway is unreachable.
+                    logger.warning("Gateway logout request failed; clearing local state")
+                }
+            } else if (did != null) {
+                logger.info("No gateway session for selected DID; clearing local state")
+            }
+        } finally {
+            clearLogoutState(did)
         }
         logger.info("Gateway logout complete")
     }
@@ -346,9 +354,8 @@ class ConfidentialGatewayStrategy(
                 }
 
                 is UnauthorizedDisposition.Transient -> {
-                    val preview = String(responseBody, Charsets.UTF_8).take(200)
                     logger.warning(
-                        "Gateway returned transient 401 (${disposition.reason}) — preserving session. Body: $preview",
+                        "Gateway returned transient 401 (${disposition.reason}) — preserving session",
                     )
                     throw GatewayException.AuthenticationRequired()
                 }
@@ -441,17 +448,39 @@ class ConfidentialGatewayStrategy(
         return UnauthorizedDisposition.Transient("unknown_401")
     }
 
+    private suspend fun clearLogoutState(did: String?) = mutex.withLock {
+        try {
+            if (did != null) {
+                runCatching { storage.deleteSession(did) }
+                    .onFailure { logCleanupFailure("delete gateway session", it) }
+            }
+            runCatching { currentAccount.setCurrentDid(null) }
+                .onFailure { logCleanupFailure("clear current account", it) }
+        } finally {
+            networkService.authenticatedDID = null
+            networkService.authorizationHeader = null
+        }
+    }
+
     private suspend fun clearCurrentGatewaySession() = mutex.withLock {
-        val did = currentAccount.getCurrentDid()
-        if (did == null) {
-            logger.warning("No current account available while clearing gateway session")
-            return@withLock
+        try {
+            val did = runCatching { currentAccount.getCurrentDid() }
+                .onFailure { logCleanupFailure("read current account during 401 handling", it) }
+                .getOrNull()
+            if (did == null) {
+                logger.warning("No current account available while clearing gateway session")
+            } else {
+                runCatching { storage.deleteSession(did) }
+                    .onFailure { logCleanupFailure("delete gateway session during 401 handling", it) }
+            }
+        } finally {
+            networkService.authenticatedDID = null
+            networkService.authorizationHeader = null
         }
-        runCatching { storage.deleteSession(did) }.onFailure {
-            logger.severe("Failed to delete gateway session during 401 handling: ${it.message}")
-        }
-        networkService.authenticatedDID = null
-        networkService.authorizationHeader = null
+    }
+
+    private fun logCleanupFailure(operation: String, failure: Throwable) {
+        logger.severe("Failed to $operation (${failure::class.simpleName ?: "Throwable"})")
     }
 
     private fun parseCallbackCode(rawUrl: String): String {
@@ -479,23 +508,30 @@ class ConfidentialGatewayStrategy(
 
     private suspend fun exchangeCode(code: String, browserNonce: String): String {
         val response = try {
-            http.post(composeGatewayUrl("/auth/exchange")) {
-                header("Origin", callback.origin)
-                header("Content-Type", "application/json")
-                header("Accept", "application/json")
-                setBody(
-                    json.encodeToString(
-                        GatewayExchangeRequest.serializer(),
-                        GatewayExchangeRequest(code, browserNonce),
-                    ),
-                )
+            withContext(Dispatchers.IO) {
+                withTimeout(requestTimeoutMillis) {
+                    http.post(composeGatewayUrl("/auth/exchange")) {
+                        header("Origin", callback.origin)
+                        header("Content-Type", "application/json")
+                        header("Accept", "application/json")
+                        setBody(
+                            json.encodeToString(
+                                GatewayExchangeRequest.serializer(),
+                                GatewayExchangeRequest(code, browserNonce),
+                            ),
+                        )
+                    }
+                }
             }
         } catch (t: Throwable) {
             throw GatewayException.NetworkError(t)
         }
         if (response.status != HttpStatusCode.OK) throw GatewayException.InvalidSession()
         val payload = runCatching {
-            json.decodeFromString(GatewayExchangeResponse.serializer(), response.bodyAsText())
+            json.decodeFromString(
+                GatewayExchangeResponse.serializer(),
+                readBoundedBody(response, MAX_EXCHANGE_RESPONSE_BYTES),
+            )
         }.getOrElse { throw GatewayException.InvalidSession() }
         return payload.session_id.takeIf(::isValidSessionId)
             ?: throw GatewayException.InvalidSession()
@@ -505,9 +541,13 @@ class ConfidentialGatewayStrategy(
     private suspend fun fetchSessionFromGateway(sessionId: String): GatewaySessionResponse {
         val url = composeGatewayUrl("/auth/session")
         val response: HttpResponse = try {
-            http.get(url) {
-                header("Authorization", "Bearer $sessionId")
-                header("Accept", "application/json")
+            withContext(Dispatchers.IO) {
+                withTimeout(requestTimeoutMillis) {
+                    http.get(url) {
+                        header("Authorization", "Bearer $sessionId")
+                        header("Accept", "application/json")
+                    }
+                }
             }
         } catch (t: Throwable) {
             throw GatewayException.NetworkError(t)
@@ -515,7 +555,9 @@ class ConfidentialGatewayStrategy(
 
         return when (response.status) {
             HttpStatusCode.OK -> {
-                val text = runCatching { response.bodyAsText() }.getOrNull()
+                val text = runCatching {
+                    readBoundedBody(response, MAX_SESSION_RESPONSE_BYTES)
+                }.getOrNull()
                     ?: throw GatewayException.InvalidSession()
                 try {
                     json.decodeFromString(GatewaySessionResponse.serializer(), text)
@@ -525,6 +567,23 @@ class ConfidentialGatewayStrategy(
             }
             HttpStatusCode.Unauthorized -> throw GatewayException.SessionExpired()
             else -> throw GatewayException.InvalidSession()
+        }
+    }
+
+    private suspend fun readBoundedBody(response: HttpResponse, maxBytes: Long): String {
+        return withContext(Dispatchers.IO) {
+            withTimeout(requestTimeoutMillis) {
+                val declaredLength = response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+                if (declaredLength != null && declaredLength > maxBytes) {
+                    throw IllegalArgumentException("Gateway response exceeded size limit")
+                }
+                val packet = response.bodyAsChannel().readRemaining(maxBytes + 1)
+                val bytes = packet.readByteArray()
+                if (bytes.size > maxBytes) {
+                    throw IllegalArgumentException("Gateway response exceeded size limit")
+                }
+                bytes.decodeToString()
+            }
         }
     }
 
@@ -555,6 +614,9 @@ class ConfidentialGatewayStrategy(
         private const val EXCHANGE_CODE_LENGTH = 43
         private const val MIN_SESSION_ID_LENGTH = 16
         private const val MAX_SESSION_ID_LENGTH = 256
+        private const val MAX_EXCHANGE_RESPONSE_BYTES = 4_096L
+        private const val MAX_SESSION_RESPONSE_BYTES = 8_192L
+        private const val DEFAULT_GATEWAY_REQUEST_TIMEOUT_MILLIS = 10_000L
         private val secureRandom = SecureRandom()
 
         private fun newSecureNonce(): ByteArray =

--- a/kotlin/src/main/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayStrategy.kt
+++ b/kotlin/src/main/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayStrategy.kt
@@ -7,14 +7,17 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
-import io.ktor.http.parseQueryString
 import io.ktor.serialization.kotlinx.json.json
+import java.net.URI
+import java.security.SecureRandom
+import java.util.Base64
 import java.util.logging.Logger
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,6 +34,17 @@ data class GatewaySessionResponse(
     val did: String,
     val handle: String? = null,
     val active: Boolean? = null,
+)
+
+@Serializable
+private data class GatewayExchangeRequest(
+    val code: String,
+    val browser_nonce: String,
+)
+
+@Serializable
+private data class GatewayExchangeResponse(
+    val session_id: String,
 )
 
 /** Failure modes for the gateway auth strategy. Mirrors Swift's `GatewayError`. */
@@ -82,6 +96,7 @@ data class GatewayCallbackResult(
  */
 class ConfidentialGatewayStrategy(
     gatewayBaseUrl: String,
+    callbackUrl: String,
     private val storage: GatewaySessionStorage,
     private val currentAccount: CurrentAccount,
     private val networkService: NetworkService,
@@ -98,6 +113,8 @@ class ConfidentialGatewayStrategy(
         .getOrElse { throw GatewayException.InvalidGatewayUrl() }
 
     private val gatewayHost: String = gatewayUrl.host
+
+    private val callback: CallbackConfiguration = validateCallbackUrl(callbackUrl)
 
     /**
      * Dedicated HTTP client for gateway endpoints (`/auth/login`, `/auth/session`,
@@ -117,6 +134,9 @@ class ConfidentialGatewayStrategy(
     /** Serializes all mutations of storage / currentAccount / networkService fields. */
     private val mutex = Mutex()
 
+    /** A login nonce deliberately has no persistence beyond this process. */
+    private var pendingBrowserNonce: String? = null
+
     /** Shared lenient JSON parser — created once per strategy instance. */
     private val json: Json = Json {
         ignoreUnknownKeys = true
@@ -128,46 +148,49 @@ class ConfidentialGatewayStrategy(
     // --------------------------------------------------------------------
 
     /**
-     * Build the gateway login URL. The returned URL is bare — we NEVER
-     * append `redirect_to` or `client` here; the gateway's own config drives
-     * the OAuth flow end-to-end.
+     * Build the gateway login URL with the exact configured callback and a
+     * per-login nonce retained only in this strategy instance.
      */
     suspend fun startOAuthFlow(identifier: String? = null): String {
-        val builder = URLBuilder(gatewayUrl).apply {
-            encodedPathSegments = listOf("auth", "login")
-            parameters.clear()
-            if (identifier != null) {
-                parameters.append("identifier", identifier)
-            }
-        }
-        return builder.buildString()
+        return buildLoginUrl("identifier", identifier)
     }
 
     /**
      * Variant that lets the caller propose a specific PDS host for sign-up.
      */
     suspend fun startOAuthFlowForSignUp(pdsUrl: String? = null): String {
+        return buildLoginUrl("pds", pdsUrl)
+    }
+
+    private suspend fun buildLoginUrl(optionalKey: String, optionalValue: String?): String {
+        val nonceBytes = newSecureNonce()
+        val nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes)
+        mutex.withLock { pendingBrowserNonce = nonce }
+
         val builder = URLBuilder(gatewayUrl).apply {
             encodedPathSegments = listOf("auth", "login")
             parameters.clear()
-            if (pdsUrl != null) {
-                parameters.append("pds", pdsUrl)
+            parameters.append("browser_nonce", nonce)
+            parameters.append("redirect_to", callback.target)
+            if (optionalValue != null) {
+                parameters.append(optionalKey, optionalValue)
             }
         }
         return builder.buildString()
     }
 
     /**
-     * Handle the gateway's redirect back to our app. Parses `session_id` from
-     * the URL fragment (the gateway puts NOTHING else in the fragment), then
-     * calls `GET {gateway}/auth/session` with that bearer to retrieve the
-     * canonical DID / handle.
+     * Redeem the single-use callback code, then hydrate the session using the
+     * existing authenticated `/auth/session` endpoint.
      */
     suspend fun handleOAuthCallback(callbackUrl: String): GatewayCallbackResult {
-        val fragment = extractFragment(callbackUrl)
-            ?: throw GatewayException.InvalidCallbackUrl()
-        val sessionId = parseSessionIdFromFragment(fragment)
-            ?: throw GatewayException.InvalidCallbackUrl()
+        val code = parseCallbackCode(callbackUrl)
+        // Consume before the first suspension/network boundary. A failed or
+        // cancelled exchange can never retry with the same browser binding.
+        val browserNonce = mutex.withLock {
+            pendingBrowserNonce.also { pendingBrowserNonce = null }
+        } ?: throw GatewayException.InvalidCallbackUrl()
+        val sessionId = exchangeCode(code, browserNonce)
 
         // Fetch session details FIRST so we key the local save by the server-
         // authoritative DID.
@@ -431,26 +454,51 @@ class ConfidentialGatewayStrategy(
         networkService.authorizationHeader = null
     }
 
-    /**
-     * Pulls `session_id` out of a URL fragment like `session_id=abc123&foo=bar`.
-     * Other keys in the fragment are ignored (nest only puts `session_id`
-     * there today, but we tolerate extras).
-     */
-    internal fun parseSessionIdFromFragment(fragment: String): String? {
-        val parsed = runCatching { parseQueryString(fragment) }.getOrNull()
-        val fromParser = parsed?.get("session_id")
-        if (!fromParser.isNullOrEmpty()) return fromParser
-
-        // Fallback: manual parse matches Swift's `split("&").split("=", 1)`
-        // logic for pathological inputs.
-        for (pair in fragment.split("&")) {
-            val idx = pair.indexOf('=')
-            if (idx <= 0) continue
-            val key = pair.substring(0, idx)
-            val value = pair.substring(idx + 1)
-            if (key == "session_id" && value.isNotEmpty()) return value
+    private fun parseCallbackCode(rawUrl: String): String {
+        val uri = runCatching { URI(rawUrl) }
+            .getOrElse { throw GatewayException.InvalidCallbackUrl() }
+        if (uri.rawUserInfo != null || uri.rawFragment != null ||
+            uri.scheme?.lowercase() != callback.scheme ||
+            uri.host?.lowercase() != callback.host ||
+            normalizedPort(uri) != callback.port ||
+            (uri.rawPath.ifEmpty { "/" }) != callback.path
+        ) {
+            throw GatewayException.InvalidCallbackUrl()
         }
-        return null
+        val query = uri.rawQuery ?: throw GatewayException.InvalidCallbackUrl()
+        val pairs = query.split('&')
+        if (pairs.size != 1) throw GatewayException.InvalidCallbackUrl()
+        val pair = pairs.single().split('=', limit = 2)
+        if (pair.size != 2 || pair[0] != "code") throw GatewayException.InvalidCallbackUrl()
+        val code = pair[1]
+        if (code.length != EXCHANGE_CODE_LENGTH || !code.all(::isBase64UrlCharacter)) {
+            throw GatewayException.InvalidCallbackUrl()
+        }
+        return code
+    }
+
+    private suspend fun exchangeCode(code: String, browserNonce: String): String {
+        val response = try {
+            http.post(composeGatewayUrl("/auth/exchange")) {
+                header("Origin", callback.origin)
+                header("Content-Type", "application/json")
+                header("Accept", "application/json")
+                setBody(
+                    json.encodeToString(
+                        GatewayExchangeRequest.serializer(),
+                        GatewayExchangeRequest(code, browserNonce),
+                    ),
+                )
+            }
+        } catch (t: Throwable) {
+            throw GatewayException.NetworkError(t)
+        }
+        if (response.status != HttpStatusCode.OK) throw GatewayException.InvalidSession()
+        val payload = runCatching {
+            json.decodeFromString(GatewayExchangeResponse.serializer(), response.bodyAsText())
+        }.getOrElse { throw GatewayException.InvalidSession() }
+        return payload.session_id.takeIf(::isValidSessionId)
+            ?: throw GatewayException.InvalidSession()
     }
 
     /** GET `{gateway}/auth/session` with the candidate bearer; parse out DID/handle. */
@@ -488,14 +536,72 @@ class ConfidentialGatewayStrategy(
         }.buildString()
     }
 
-    private fun extractFragment(rawUrl: String): String? {
-        val hashIdx = rawUrl.indexOf('#')
-        if (hashIdx < 0 || hashIdx == rawUrl.length - 1) return null
-        return rawUrl.substring(hashIdx + 1)
-    }
-
     /** Release network resources. Safe to call multiple times. */
     fun close() {
         http.close()
+    }
+
+    private data class CallbackConfiguration(
+        val target: String,
+        val scheme: String,
+        val host: String,
+        val port: Int,
+        val path: String,
+        val origin: String,
+    )
+
+    companion object {
+        private const val NONCE_BYTE_COUNT = 32
+        private const val EXCHANGE_CODE_LENGTH = 43
+        private const val MIN_SESSION_ID_LENGTH = 16
+        private const val MAX_SESSION_ID_LENGTH = 256
+        private val secureRandom = SecureRandom()
+
+        private fun newSecureNonce(): ByteArray =
+            ByteArray(NONCE_BYTE_COUNT).also(secureRandom::nextBytes)
+
+        private fun isBase64UrlCharacter(character: Char): Boolean =
+            character in 'A'..'Z' ||
+                character in 'a'..'z' ||
+                character in '0'..'9' ||
+                character == '-' ||
+                character == '_'
+
+        private fun isValidSessionId(value: String): Boolean =
+            value.length in MIN_SESSION_ID_LENGTH..MAX_SESSION_ID_LENGTH &&
+                value.all {
+                    isBase64UrlCharacter(it) || it == '.' || it == '~'
+                }
+
+        private fun validateCallbackUrl(rawUrl: String): CallbackConfiguration {
+            val uri = runCatching { URI(rawUrl) }
+                .getOrElse { throw GatewayException.InvalidCallbackUrl() }
+            val scheme = uri.scheme?.lowercase() ?: throw GatewayException.InvalidCallbackUrl()
+            val host = uri.host?.lowercase() ?: throw GatewayException.InvalidCallbackUrl()
+            if (uri.rawUserInfo != null || uri.rawQuery != null || uri.rawFragment != null) {
+                throw GatewayException.InvalidCallbackUrl()
+            }
+            val port = normalizedPort(uri)
+            val allowed = when (scheme) {
+                "https" -> port == 443
+                "http" -> host in setOf("127.0.0.1", "::1") && uri.port in 1..65535
+                else -> false
+            }
+            if (!allowed) throw GatewayException.InvalidCallbackUrl()
+            val path = uri.rawPath.ifEmpty { "/" }
+            val authorityHost = if (host.contains(':')) "[$host]" else host
+            val origin = when {
+                scheme == "https" -> "https://$authorityHost"
+                else -> "http://$authorityHost:${uri.port}"
+            }
+            return CallbackConfiguration(rawUrl, scheme, host, port, path, origin)
+        }
+
+        private fun normalizedPort(uri: URI): Int = when {
+            uri.port >= 0 -> uri.port
+            uri.scheme.equals("https", ignoreCase = true) -> 443
+            uri.scheme.equals("http", ignoreCase = true) -> 80
+            else -> -1
+        }
     }
 }

--- a/kotlin/src/main/kotlin/blue/catbird/petrel/client/ATProtoClientGatewayExt.kt
+++ b/kotlin/src/main/kotlin/blue/catbird/petrel/client/ATProtoClientGatewayExt.kt
@@ -32,6 +32,7 @@ private val strategies: MutableMap<ATProtoClient, ConfidentialGatewayStrategy> =
  *
  * @param gatewayBaseUrl Root URL of the confidential gateway (nest), e.g.
  *                       `https://api.catbird.blue`. Must NOT end in `/xrpc`.
+ * @param callbackUrl    Exact callback URL registered for this consumer.
  * @param storage        Persistent store for gateway session UUIDs (per-DID).
  *                       Android apps should back this with
  *                       `EncryptedSharedPreferences`.
@@ -41,6 +42,7 @@ private val strategies: MutableMap<ATProtoClient, ConfidentialGatewayStrategy> =
  */
 fun ATProtoClient.configureGateway(
     gatewayBaseUrl: String,
+    callbackUrl: String,
     storage: GatewaySessionStorage,
     currentAccount: CurrentAccount,
 ): ConfidentialGatewayStrategy {
@@ -49,6 +51,7 @@ fun ATProtoClient.configureGateway(
 
     val strategy = ConfidentialGatewayStrategy(
         gatewayBaseUrl = gatewayBaseUrl,
+        callbackUrl = callbackUrl,
         storage = storage,
         currentAccount = currentAccount,
         networkService = networkService,

--- a/kotlin/src/main/kotlin/blue/catbird/petrel/generated/client/ATProtoClientGenerated.kt
+++ b/kotlin/src/main/kotlin/blue/catbird/petrel/generated/client/ATProtoClientGenerated.kt
@@ -102,31 +102,14 @@ class ATProtoClient(val networkService: NetworkService) {
     }
 
     @Deprecated(
-        "Broken: parses did/handle from fragment but nest only sends session_id. " +
-            "Use ATProtoClient.configureGateway(...) + gatewayHandleCallback(url) which " +
-            "fetches canonical session info from GET /auth/session.",
+        "Disabled: URL-carried session credentials are unsafe. Use " +
+            "ATProtoClient.configureGateway(...) + gatewayHandleCallback(url).",
         ReplaceWith("gatewayHandleCallback(callbackUrl)"),
     )
     fun handleGatewayCallback(callbackUrl: String): GatewaySessionInfo {
-        val fragment = callbackUrl.substringAfter("#", "")
-        val params = fragment.split("&").associate { part ->
-            val (key, value) = part.split("=", limit = 2)
-            key to java.net.URLDecoder.decode(value, "UTF-8")
-        }
-
-        val sessionId = params["session_id"]
-            ?: throw IllegalArgumentException("Gateway callback missing session_id")
-
-        val session = GatewaySessionInfo(
-            sessionId = sessionId,
-            did = params["did"] ?: "",
-            handle = params["handle"]
+        throw UnsupportedOperationException(
+            "Legacy gateway callbacks are disabled; use the single-use exchange flow",
         )
-        gatewaySession = session
-        networkService.authenticatedDID = session.did
-        networkService.authorizationHeader = "Bearer $sessionId"
-        authMode = AuthMode.Gateway
-        return session
     }
 
     @Deprecated(

--- a/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayExchangeTest.kt
+++ b/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayExchangeTest.kt
@@ -1,0 +1,264 @@
+package blue.catbird.petrel.auth.gateway
+
+import blue.catbird.petrel.network.NetworkService
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.http.parameters
+import io.ktor.http.toURI
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+
+class ConfidentialGatewayExchangeTest {
+    private val callbackUrl = "https://catbird.blue/oauth/callback"
+    private val code = "A".repeat(43)
+    private val sessionId = "123e4567-e89b-12d3-a456-426614174000"
+
+    @Test
+    fun `login carries exact redirect and fresh 32-byte base64url browser nonce`() = runTest {
+        val strategy = strategy()
+
+        val first = io.ktor.http.Url(strategy.startOAuthFlow("did:plc:alice"))
+        val second = io.ktor.http.Url(strategy.startOAuthFlow("did:plc:alice"))
+
+        assertEquals(callbackUrl, first.parameters["redirect_to"])
+        assertEquals("did:plc:alice", first.parameters["identifier"])
+        val firstNonce = requireNotNull(first.parameters["browser_nonce"])
+        val secondNonce = requireNotNull(second.parameters["browser_nonce"])
+        assertEquals(43, firstNonce.length)
+        assertEquals(32, Base64.getUrlDecoder().decode(firstNonce).size)
+        assertTrue(firstNonce.all { it.isLetterOrDigit() || it == '-' || it == '_' })
+        assertNotEquals(firstNonce, secondNonce)
+    }
+
+    @Test
+    fun `callback exchanges one code with nonce and exact origin then hydrates session`() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val strategy = strategy(httpClient = exchangeClient(requests))
+        val loginUrl = io.ktor.http.Url(strategy.startOAuthFlow("alice.test"))
+        val nonce = requireNotNull(loginUrl.parameters["browser_nonce"])
+
+        val result = strategy.handleOAuthCallback("$callbackUrl?code=$code")
+
+        assertEquals("did:plc:alice", result.did)
+        assertEquals(2, requests.size)
+        assertEquals("/auth/exchange", requests[0].path)
+        assertEquals("https://catbird.blue", requests[0].origin)
+        assertTrue(requests[0].body.contains("\"code\":\"$code\""))
+        assertTrue(requests[0].body.contains("\"browser_nonce\":\"$nonce\""))
+        assertFalse(requests[0].body.contains("redirect_to"))
+        assertEquals("/auth/session", requests[1].path)
+        assertEquals("Bearer $sessionId", requests[1].authorization)
+        assertEquals("Bearer $sessionId", strategyNetworkService.authorizationHeader)
+        assertEquals("did:plc:alice", strategyStorage.getCurrentDid())
+        assertEquals(sessionId, strategyStorage.getSession("did:plc:alice"))
+    }
+
+    @Test
+    fun `callback must exactly match configured URL and contain one canonical code`() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val strategy = strategy(httpClient = exchangeClient(requests))
+        strategy.startOAuthFlow()
+
+        val invalidCallbacks = listOf(
+            "https://catbird.blue.evil/oauth/callback?code=$code",
+            "https://catbird.blue/other?code=$code",
+            "$callbackUrl?code=$code&code=${"B".repeat(43)}",
+            "$callbackUrl?code=short",
+            "$callbackUrl?code=${"é".repeat(43)}",
+            "$callbackUrl?code=$code&extra=1",
+            "$callbackUrl?code=$code#fragment",
+        )
+        for (callback in invalidCallbacks) {
+            assertFailsWith<GatewayException.InvalidCallbackUrl> {
+                strategy.handleOAuthCallback(callback)
+            }
+        }
+        assertTrue(requests.isEmpty())
+    }
+
+    @Test
+    fun `pending nonce is consumed before exchange and failure never falls back`() = runTest {
+        var exchangeCount = 0
+        val client = HttpClient(MockEngine { request ->
+            if (request.url.encodedPath == "/auth/exchange") {
+                exchangeCount++
+                respond("unauthorized", HttpStatusCode.Unauthorized)
+            } else {
+                error("legacy session hydration must not run")
+            }
+        })
+        val strategy = strategy(httpClient = client)
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertFailsWith<GatewayException.InvalidCallbackUrl> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertEquals(1, exchangeCount)
+    }
+
+    @Test
+    fun `callback without an in-memory pending login fails closed`() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val strategy = strategy(httpClient = exchangeClient(requests))
+
+        assertFailsWith<GatewayException.InvalidCallbackUrl> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertTrue(requests.isEmpty())
+    }
+
+    @Test
+    fun `exchange rejects unbounded session credential before hydration or storage`() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val strategy = strategy(
+            httpClient = exchangeClient(requests, exchangeSessionId = "x".repeat(257)),
+        )
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertEquals(listOf("/auth/exchange"), requests.map { it.path })
+        assertNull(strategyStorage.getCurrentDid())
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
+    fun `exchange rejects unicode session credential before hydration or storage`() = runTest {
+        val requests = mutableListOf<CapturedRequest>()
+        val strategy = strategy(
+            httpClient = exchangeClient(requests, exchangeSessionId = "é".repeat(36)),
+        )
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertEquals(listOf("/auth/exchange"), requests.map { it.path })
+        assertNull(strategyStorage.getCurrentDid())
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
+    fun `simultaneous callbacks consume nonce once and send one exchange request`() = runTest {
+        val exchangeStarted = CompletableDeferred<Unit>()
+        val releaseExchange = CompletableDeferred<Unit>()
+        val exchangeCount = AtomicInteger()
+        val client = HttpClient(MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/auth/exchange" -> {
+                    exchangeCount.incrementAndGet()
+                    exchangeStarted.complete(Unit)
+                    releaseExchange.await()
+                    respond(
+                        content = "{\"session_id\":\"$sessionId\"}",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+                "/auth/session" -> respond(
+                    content = "{\"did\":\"did:plc:alice\"}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                else -> error("unexpected request ${request.url}")
+            }
+        })
+        val strategy = strategy(httpClient = client)
+        strategy.startOAuthFlow()
+
+        val first = async { runCatching { strategy.handleOAuthCallback("$callbackUrl?code=$code") } }
+        exchangeStarted.await()
+        val second = async { runCatching { strategy.handleOAuthCallback("$callbackUrl?code=$code") } }
+        assertTrue(second.await().exceptionOrNull() is GatewayException.InvalidCallbackUrl)
+        releaseExchange.complete(Unit)
+        assertTrue(first.await().isSuccess)
+        assertEquals(1, exchangeCount.get())
+    }
+
+    @Test
+    fun `configured callback rejects credentials fragments and insecure public origins`() {
+        for (invalid in listOf(
+            "https://user@catbird.blue/oauth/callback",
+            "https://catbird.blue/oauth/callback#fragment",
+            "http://catbird.blue/oauth/callback",
+            "https://catbird.blue:444/oauth/callback",
+        )) {
+            assertFailsWith<GatewayException.InvalidCallbackUrl> {
+                strategy(callbackUrl = invalid)
+            }
+        }
+    }
+
+    private lateinit var strategyStorage: InMemoryGatewaySessionStorage
+    private lateinit var strategyNetworkService: NetworkService
+
+    private fun strategy(
+        callbackUrl: String = this.callbackUrl,
+        httpClient: HttpClient = HttpClient(MockEngine { error("unexpected request") }),
+    ): ConfidentialGatewayStrategy {
+        strategyStorage = InMemoryGatewaySessionStorage()
+        strategyNetworkService = NetworkService("https://api.catbird.blue")
+        return ConfidentialGatewayStrategy(
+            gatewayBaseUrl = "https://api.catbird.blue",
+            callbackUrl = callbackUrl,
+            storage = strategyStorage,
+            currentAccount = strategyStorage,
+            networkService = strategyNetworkService,
+            httpClient = httpClient,
+        )
+    }
+
+    private fun exchangeClient(
+        requests: MutableList<CapturedRequest>,
+        exchangeSessionId: String = sessionId,
+    ): HttpClient = HttpClient(MockEngine { request ->
+        requests += CapturedRequest(
+            path = request.url.encodedPath,
+            origin = request.headers[HttpHeaders.Origin],
+            authorization = request.headers[HttpHeaders.Authorization],
+            body = (request.body as? OutgoingContent.ByteArrayContent)
+                ?.bytes()
+                ?.decodeToString()
+                .orEmpty(),
+        )
+        when (request.url.encodedPath) {
+            "/auth/exchange" -> respond(
+                content = "{\"session_id\":\"$exchangeSessionId\"}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+            "/auth/session" -> respond(
+                content = "{\"did\":\"did:plc:alice\",\"handle\":\"alice.test\"}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+            else -> error("unexpected request ${request.url.toURI()}")
+        }
+    })
+
+    private data class CapturedRequest(
+        val path: String,
+        val origin: String?,
+        val authorization: String?,
+        val body: String,
+    )
+}

--- a/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayExchangeTest.kt
+++ b/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayExchangeTest.kt
@@ -4,6 +4,7 @@ import blue.catbird.petrel.network.NetworkService
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
@@ -21,6 +22,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 
 class ConfidentialGatewayExchangeTest {
@@ -158,6 +160,89 @@ class ConfidentialGatewayExchangeTest {
     }
 
     @Test
+    fun `exchange rejects oversized response declared by content length`() = runTest {
+        val oversized = "{\"session_id\":\"$sessionId\",\"padding\":\"${"x".repeat(4097)}\"}"
+        val client = HttpClient(MockEngine {
+            respond(
+                content = oversized,
+                status = HttpStatusCode.OK,
+                headers = headersOf(
+                    HttpHeaders.ContentType to listOf("application/json"),
+                    HttpHeaders.ContentLength to listOf(oversized.encodeToByteArray().size.toString()),
+                ),
+            )
+        })
+        val strategy = strategy(httpClient = client)
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
+    fun `exchange rejects oversized response without content length`() = runTest {
+        val client = HttpClient(MockEngine {
+            respond(
+                content = "{\"session_id\":\"$sessionId\",\"padding\":\"${"x".repeat(4097)}\"}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        })
+        val strategy = strategy(httpClient = client)
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
+    fun `session hydration rejects oversized response without content length`() = runTest {
+        val client = HttpClient(MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/auth/exchange" -> respond(
+                    content = "{\"session_id\":\"$sessionId\"}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                "/auth/session" -> respond(
+                    content = "{\"did\":\"did:plc:alice\",\"padding\":\"${"x".repeat(8193)}\"}",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        })
+        val strategy = strategy(httpClient = client)
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.InvalidSession> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertNull(strategyStorage.getCurrentDid())
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
+    fun `gateway requests time out and do not install credentials`() = runTest {
+        val client = HttpClient(MockEngine {
+            delay(60_000)
+            respond("{}", HttpStatusCode.OK)
+        })
+        val strategy = strategy(httpClient = client, requestTimeoutMillis = 100)
+        strategy.startOAuthFlow()
+
+        assertFailsWith<GatewayException.NetworkError> {
+            strategy.handleOAuthCallback("$callbackUrl?code=$code")
+        }
+        assertNull(strategyStorage.getCurrentDid())
+        assertNull(strategyNetworkService.authorizationHeader)
+    }
+
+    @Test
     fun `simultaneous callbacks consume nonce once and send one exchange request`() = runTest {
         val exchangeStarted = CompletableDeferred<Unit>()
         val releaseExchange = CompletableDeferred<Unit>()
@@ -214,6 +299,7 @@ class ConfidentialGatewayExchangeTest {
     private fun strategy(
         callbackUrl: String = this.callbackUrl,
         httpClient: HttpClient = HttpClient(MockEngine { error("unexpected request") }),
+        requestTimeoutMillis: Long = 10_000,
     ): ConfidentialGatewayStrategy {
         strategyStorage = InMemoryGatewaySessionStorage()
         strategyNetworkService = NetworkService("https://api.catbird.blue")
@@ -224,6 +310,7 @@ class ConfidentialGatewayExchangeTest {
             currentAccount = strategyStorage,
             networkService = strategyNetworkService,
             httpClient = httpClient,
+            requestTimeoutMillis = requestTimeoutMillis,
         )
     }
 

--- a/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayLifecycleTest.kt
+++ b/kotlin/src/test/kotlin/blue/catbird/petrel/auth/gateway/ConfidentialGatewayLifecycleTest.kt
@@ -1,0 +1,245 @@
+package blue.catbird.petrel.auth.gateway
+
+import blue.catbird.petrel.network.NetworkService
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import java.io.IOException
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+class ConfidentialGatewayLifecycleTest {
+    private val did = "did:plc:alice"
+    private val sessionId = "123e4567-e89b-12d3-a456-426614174000"
+
+    @Test
+    fun `restore wires stored session into current account and network service`() = runTest {
+        val fixture = fixture(HttpClient(MockEngine { error("unexpected request") }))
+        fixture.storage.saveSession(did, sessionId)
+
+        assertEquals(sessionId, fixture.strategy.restoreSession(did))
+        assertEquals(did, fixture.storage.getCurrentDid())
+        assertEquals(did, fixture.network.authenticatedDID)
+        assertEquals("Bearer $sessionId", fixture.network.authorizationHeader)
+    }
+
+    @Test
+    fun `logout success clears all local credential state`() = runTest {
+        val fixture = authenticatedFixture(HttpClient(MockEngine {
+            respond("", HttpStatusCode.OK)
+        }))
+
+        fixture.strategy.logout()
+
+        assertLocallyLoggedOut(fixture)
+    }
+
+    @Test
+    fun `logout non success clears local state without logging response secrets`() = runTest {
+        val fixture = authenticatedFixture(HttpClient(MockEngine {
+            respond("upstream echoed $sessionId", HttpStatusCode.BadGateway)
+        }))
+        val logs = captureLogs {
+            fixture.strategy.logout()
+        }
+
+        assertLocallyLoggedOut(fixture)
+        assertFalse(logs.contains(sessionId), logs)
+    }
+
+    @Test
+    fun `logout network failure clears local state without logging exception secrets`() = runTest {
+        val fixture = authenticatedFixture(HttpClient(MockEngine {
+            throw IOException("network failed for bearer $sessionId")
+        }))
+        val logs = captureLogs {
+            fixture.strategy.logout()
+        }
+
+        assertLocallyLoggedOut(fixture)
+        assertFalse(logs.contains(sessionId), logs)
+    }
+
+    @Test
+    fun `logout clears stale network bearer when current DID is missing`() = runTest {
+        val fixture = fixture(HttpClient(MockEngine { error("unexpected request") }))
+        fixture.network.authenticatedDID = did
+        fixture.network.authorizationHeader = "Bearer $sessionId"
+
+        fixture.strategy.logout()
+
+        assertNull(fixture.network.authenticatedDID)
+        assertNull(fixture.network.authorizationHeader)
+    }
+
+    @Test
+    fun `logout clears network bearer independently when storage cleanup throws`() = runTest {
+        val storage = ThrowingStorage(
+            currentDid = did,
+            sessionId = sessionId,
+            deleteFailure = IOException("delete failed with $sessionId"),
+            setCurrentFailure = IOException("selection failed with $sessionId"),
+        )
+        val network = NetworkService("https://api.catbird.blue").apply {
+            authenticatedDID = did
+            authorizationHeader = "Bearer $sessionId"
+        }
+        val strategy = ConfidentialGatewayStrategy(
+            gatewayBaseUrl = "https://api.catbird.blue",
+            callbackUrl = "https://catbird.blue/oauth/callback",
+            storage = storage,
+            currentAccount = storage,
+            networkService = network,
+            httpClient = HttpClient(MockEngine { respond("", HttpStatusCode.OK) }),
+        )
+
+        val logs = captureLogs { strategy.logout() }
+
+        assertNull(network.authenticatedDID)
+        assertNull(network.authorizationHeader)
+        assertFalse(logs.contains(sessionId), logs)
+    }
+
+    @Test
+    fun `transient 401 does not log sensitive response body`() = runTest {
+        val fixture = authenticatedFixture(HttpClient(MockEngine { error("unexpected request") }))
+        val marker = "sensitive-upstream-body-$sessionId"
+
+        val logs = captureLogs {
+            assertFailsWith<GatewayException.AuthenticationRequired> {
+                fixture.strategy.handleUnauthorizedResponse(
+                    "api.catbird.blue",
+                    "temporarily unavailable $marker".encodeToByteArray(),
+                )
+            }
+        }
+
+        assertFalse(logs.contains(marker), logs)
+        assertFalse(logs.contains(sessionId), logs)
+    }
+
+    @Test
+    fun `terminal 401 storage failure logs only error class`() = runTest {
+        val marker = "sensitive-storage-message-$sessionId"
+        val storage = ThrowingStorage(
+            currentDid = did,
+            sessionId = sessionId,
+            deleteFailure = IOException(marker),
+        )
+        val network = NetworkService("https://api.catbird.blue").apply {
+            authenticatedDID = did
+            authorizationHeader = "Bearer $sessionId"
+        }
+        val strategy = ConfidentialGatewayStrategy(
+            gatewayBaseUrl = "https://api.catbird.blue",
+            callbackUrl = "https://catbird.blue/oauth/callback",
+            storage = storage,
+            currentAccount = storage,
+            networkService = network,
+            httpClient = HttpClient(MockEngine { error("unexpected request") }),
+        )
+
+        val logs = captureLogs {
+            assertFailsWith<GatewayException.SessionExpired> {
+                strategy.handleUnauthorizedResponse(
+                    "api.catbird.blue",
+                    "{\"error\":\"invalid_session\"}".encodeToByteArray(),
+                )
+            }
+        }
+
+        assertNull(network.authenticatedDID)
+        assertNull(network.authorizationHeader)
+        assertFalse(logs.contains(marker), logs)
+        assertFalse(logs.contains(sessionId), logs)
+    }
+
+    private suspend fun authenticatedFixture(client: HttpClient): Fixture {
+        val fixture = fixture(client)
+        fixture.storage.saveSession(did, sessionId)
+        fixture.strategy.restoreSession(did)
+        return fixture
+    }
+
+    private fun fixture(client: HttpClient): Fixture {
+        val storage = InMemoryGatewaySessionStorage()
+        val network = NetworkService("https://api.catbird.blue")
+        return Fixture(
+            storage,
+            network,
+            ConfidentialGatewayStrategy(
+                gatewayBaseUrl = "https://api.catbird.blue",
+                callbackUrl = "https://catbird.blue/oauth/callback",
+                storage = storage,
+                currentAccount = storage,
+                networkService = network,
+                httpClient = client,
+            ),
+        )
+    }
+
+    private suspend fun assertLocallyLoggedOut(fixture: Fixture) {
+        assertNull(fixture.storage.getSession(did))
+        assertNull(fixture.storage.getCurrentDid())
+        assertNull(fixture.network.authenticatedDID)
+        assertNull(fixture.network.authorizationHeader)
+    }
+
+    private suspend fun captureLogs(block: suspend () -> Unit): String {
+        val records = mutableListOf<String>()
+        val logger = Logger.getLogger("ConfidentialGatewayStrategy")
+        val handler = object : Handler() {
+            override fun publish(record: LogRecord) { records += record.message }
+            override fun flush() = Unit
+            override fun close() = Unit
+        }
+        logger.addHandler(handler)
+        return try {
+            block()
+            records.joinToString("\n")
+        } finally {
+            logger.removeHandler(handler)
+        }
+    }
+
+    private data class Fixture(
+        val storage: InMemoryGatewaySessionStorage,
+        val network: NetworkService,
+        val strategy: ConfidentialGatewayStrategy,
+    )
+
+    private class ThrowingStorage(
+        private var currentDid: String?,
+        private var sessionId: String?,
+        private val deleteFailure: Throwable? = null,
+        private val setCurrentFailure: Throwable? = null,
+    ) : GatewaySessionStorage, CurrentAccount {
+        override suspend fun saveSession(did: String, sessionId: String) {
+            this.sessionId = sessionId
+        }
+
+        override suspend fun getSession(did: String): String? = sessionId
+
+        override suspend fun deleteSession(did: String) {
+            deleteFailure?.let { throw it }
+            sessionId = null
+        }
+
+        override suspend fun getAllDids(): List<String> = listOfNotNull(currentDid)
+
+        override suspend fun getCurrentDid(): String? = currentDid
+
+        override suspend fun setCurrentDid(did: String?) {
+            setCurrentFailure?.let { throw it }
+            currentDid = did
+        }
+    }
+}

--- a/kotlin/src/test/kotlin/blue/catbird/petrel/client/LegacyGatewayCallbackTest.kt
+++ b/kotlin/src/test/kotlin/blue/catbird/petrel/client/LegacyGatewayCallbackTest.kt
@@ -1,0 +1,25 @@
+package blue.catbird.petrel.client
+
+import blue.catbird.petrel.network.NetworkService
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class LegacyGatewayCallbackTest {
+    @Suppress("DEPRECATION")
+    @Test
+    fun `legacy callback refuses session credentials from URL fragments`() {
+        val network = NetworkService("https://api.catbird.blue")
+        val client = ATProtoClient(network)
+
+        assertFailsWith<UnsupportedOperationException> {
+            client.handleGatewayCallback(
+                "https://catbird.blue/oauth/callback#session_id=attacker-controlled-session",
+            )
+        }
+
+        assertNull(client.currentGatewaySessionId())
+        assertNull(network.authenticatedDID)
+        assertNull(network.authorizationHeader)
+    }
+}


### PR DESCRIPTION
## What changed

- replaces callback URL session credentials with nonce-bound, single-use exchange codes
- binds callbacks and redemption to the exact configured origin
- bounds and times out exchange/session responses and rejects redirects/legacy URL credentials
- makes logout and unauthorized cleanup failure-independent and secret-safe
- adds exchange, replay, concurrency, lifecycle, response-bound, and legacy-denial tests

## Why

Implements ADR-014 for Android and other Petrel Kotlin consumers so live Nest session credentials never transit callback URLs.

## Validation

- Gradle clean check assemble
- 18 focused OAuth/lifecycle/legacy security tests
- independent adversarial review: APPROVE
- deterministic Kotlin regeneration verified twice