### PR TITLE
security: add non-secret auth continuity snapshots

### DIFF
--- a/Sources/Petrel/Auth/AuthContinuity.swift
+++ b/Sources/Petrel/Auth/AuthContinuity.swift
@@ -1,0 +1,138 @@
+#if canImport(CryptoKit)
+    import CryptoKit
+#else
+    @preconcurrency import Crypto
+#endif
+import Foundation
+
+/// A non-secret value that binds work to the current authentication principal
+/// and gateway-session continuity.
+///
+/// The opaque gateway session identifier never crosses this API. Callers should
+/// compare the complete value before and after suspension points and discard
+/// security-sensitive work whenever it changes.
+public struct AuthContinuitySnapshot: Equatable, Sendable {
+    /// The authenticated gateway principal, or `nil` when no live gateway
+    /// session has been observed.
+    public let did: String?
+
+    /// The authentication mode represented by this snapshot.
+    public let mode: AuthMode
+
+    /// An in-memory generation that changes whenever authentication continuity
+    /// may have changed. It is intentionally not persisted across client launches.
+    public let generation: UInt64
+
+    public init(did: String?, mode: AuthMode, generation: UInt64) {
+        self.did = did
+        self.mode = mode
+        self.generation = generation
+    }
+}
+
+protocol AuthContinuityProviding: AnyObject, AuthenticationProvider {
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot
+}
+
+struct GatewayAuthIdentity: Equatable {
+    let did: String
+    private let sessionFingerprint: [UInt8]
+
+    init(did: String, session: String) {
+        self.did = did
+        sessionFingerprint = Array(SHA256.hash(data: Data(session.utf8)))
+    }
+}
+
+struct AuthContinuityState {
+    private enum Observation: Equatable {
+        case unobserved
+        case invalidated
+        case observed(GatewayAuthIdentity?)
+    }
+
+    private(set) var mode: AuthMode
+    private(set) var generation: UInt64
+    private(set) var isExhausted: Bool
+    private var observation: Observation
+
+    init(mode: AuthMode) {
+        self.mode = mode
+        generation = 0
+        isExhausted = false
+        observation = .unobserved
+    }
+
+    init(
+        mode: AuthMode,
+        generation: UInt64,
+        observedGatewayIdentity: GatewayAuthIdentity?
+    ) {
+        self.mode = mode
+        self.generation = generation
+        isExhausted = false
+        observation = .observed(observedGatewayIdentity)
+    }
+
+    var snapshot: AuthContinuitySnapshot {
+        let did: String? = if isExhausted || mode != .gateway {
+            nil
+        } else if case let .observed(identity) = observation {
+            identity?.did
+        } else {
+            nil
+        }
+
+        return AuthContinuitySnapshot(did: did, mode: mode, generation: generation)
+    }
+
+    /// Invalidates the current continuity before an operation can suspend.
+    /// Exhaustion permanently removes the principal instead of wrapping and
+    /// accidentally making two distinct authentication states compare equal.
+    mutating func invalidate() {
+        observation = .invalidated
+        guard !isExhausted else { return }
+        guard generation < .max else {
+            isExhausted = true
+            return
+        }
+        generation += 1
+    }
+
+    mutating func commitMode(_ newMode: AuthMode) {
+        mode = newMode
+        if newMode != .gateway {
+            observation = .invalidated
+        }
+    }
+
+    /// Reconciles the private underlying identity with the last observation.
+    /// Tracked mutations have already incremented the generation and leave the
+    /// state in `.invalidated`; out-of-band replacements increment here.
+    mutating func observeGatewayIdentity(_ identity: GatewayAuthIdentity?) {
+        guard mode == .gateway, !isExhausted else { return }
+
+        switch observation {
+        case .unobserved, .invalidated:
+            observation = .observed(identity)
+        case let .observed(previous) where previous != identity:
+            invalidate()
+            if !isExhausted {
+                observation = .observed(identity)
+            }
+        case .observed:
+            break
+        }
+    }
+}
+
+public extension ATProtoClient {
+    /// Returns a non-secret snapshot of the client's authentication continuity.
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        if let snapshot = await networkService.authContinuitySnapshot() {
+            return snapshot
+        }
+        return AuthContinuitySnapshot(did: nil, mode: authMode, generation: 0)
+    }
+}

--- a/Sources/Petrel/Auth/AuthManager.swift
+++ b/Sources/Petrel/Auth/AuthManager.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /// Coordinator class that manages authentication strategies.
 /// Holds a reference to the active strategy and forwards all AuthStrategy methods to it.
-actor AuthManager: AuthStrategy {
+actor AuthManager: AuthStrategy, AuthContinuityProviding {
     // MARK: - Types
 
     /// Authentication mode determining which strategy to use.
@@ -52,6 +52,8 @@ actor AuthManager: AuthStrategy {
     private let oauthConfig: OAuthConfig
     private let didResolver: DIDResolving
     private let gatewayBaseURL: URL?
+    private var authContinuity: AuthContinuityState
+    private var authContinuityObserver: (@Sendable () async -> Void)?
 
     /// The current authentication mode.
     private(set) var currentMode: Mode
@@ -84,6 +86,7 @@ actor AuthManager: AuthStrategy {
         self.didResolver = didResolver
         self.gatewayBaseURL = gatewayBaseURL
         currentMode = mode
+        authContinuity = AuthContinuityState(mode: mode.authMode)
 
         activeStrategy = try Self.createStrategy(
             mode: mode,
@@ -104,6 +107,10 @@ actor AuthManager: AuthStrategy {
     func switchMode(_ mode: Mode) async throws {
         guard mode != currentMode else { return }
 
+        // Invalidate before cancelling the old strategy because cancellation is
+        // an actor suspension point and must not leave stale work authorized.
+        await invalidateAuthContinuity()
+
         // Cancel any ongoing OAuth flow before switching
         await activeStrategy.cancelOAuthFlow()
 
@@ -117,6 +124,8 @@ actor AuthManager: AuthStrategy {
             gatewayBaseURL: gatewayBaseURL
         )
         currentMode = mode
+        authContinuity.commitMode(mode.authMode)
+        await notifyAuthContinuityMutation()
     }
 
     // MARK: - Strategy Factory
@@ -197,7 +206,23 @@ actor AuthManager: AuthStrategy {
     }
 
     func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
-        try await activeStrategy.handleOAuthCallback(url: url)
+        if currentMode == .gateway {
+            // The callback may install or replace an opaque gateway session.
+            // Invalidate before the strategy performs its first await.
+            await invalidateAuthContinuity()
+        }
+        do {
+            let result = try await activeStrategy.handleOAuthCallback(url: url)
+            if currentMode == .gateway {
+                await notifyAuthContinuityMutation()
+            }
+            return result
+        } catch {
+            if currentMode == .gateway {
+                await notifyAuthContinuityMutation()
+            }
+            throw error
+        }
     }
 
     func loginWithPassword(
@@ -215,7 +240,14 @@ actor AuthManager: AuthStrategy {
     }
 
     func logout() async throws {
-        try await activeStrategy.logout()
+        await invalidateAuthContinuity()
+        do {
+            try await activeStrategy.logout()
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
     }
 
     func cancelOAuthFlow() async {
@@ -257,10 +289,117 @@ actor AuthManager: AuthStrategy {
         data: Data,
         for request: URLRequest
     ) async throws -> (Data, HTTPURLResponse) {
-        try await activeStrategy.handleUnauthorizedResponse(response, data: data, for: request)
+        if currentMode == .gateway,
+           let gatewayBaseURL,
+           isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
+        {
+            // The strategy will clear the local session. Change continuity
+            // before forwarding across the actor boundary.
+            await invalidateAuthContinuity()
+        }
+        do {
+            let result = try await activeStrategy.handleUnauthorizedResponse(response, data: data, for: request)
+            if currentMode == .gateway,
+               let gatewayBaseURL,
+               isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
+            {
+                await notifyAuthContinuityMutation()
+            }
+            return result
+        } catch {
+            if currentMode == .gateway,
+               let gatewayBaseURL,
+               isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
+            {
+                await notifyAuthContinuityMutation()
+            }
+            throw error
+        }
     }
 
     func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
         await activeStrategy.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
+    }
+
+    // MARK: - Authentication Continuity
+
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        authContinuityObserver = observer
+        await storage.setAuthContinuityObserver { [weak self] in
+            await self?.invalidateAuthContinuityForStorageMutation()
+        }
+    }
+
+    private func invalidateAuthContinuity() async {
+        authContinuity.invalidate()
+        await notifyAuthContinuityMutation()
+    }
+
+    private func notifyAuthContinuityMutation() async {
+        await authContinuityObserver?()
+    }
+
+    private func invalidateAuthContinuityForStorageMutation() async {
+        authContinuity.invalidate()
+        await notifyAuthContinuityMutation()
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        while true {
+            let generation = authContinuity.generation
+            let mode = authContinuity.mode
+            let exhausted = authContinuity.isExhausted
+
+            guard mode == .gateway, !exhausted else {
+                return authContinuity.snapshot
+            }
+
+            // Use the versioned persistent selector rather than AccountManager's
+            // separately cached DID. KeychainStorage encloses selector and
+            // gateway-session mutations in NetworkService revision signals.
+            let did = try? await storage.getCurrentDID()
+            let session: String?
+            if let did, !did.isEmpty {
+                session = try? await storage.getGatewaySession(for: did)
+            } else {
+                session = nil
+            }
+
+            // Calls above can re-enter this actor. Retry rather than combining
+            // observations from two authentication generations or modes.
+            guard authContinuity.generation == generation,
+                  authContinuity.mode == mode,
+                  authContinuity.isExhausted == exhausted
+            else {
+                continue
+            }
+
+            let identity: GatewayAuthIdentity? = if let did, !did.isEmpty, let session {
+                GatewayAuthIdentity(did: did, session: session)
+            } else {
+                nil
+            }
+            let previousGeneration = authContinuity.generation
+            authContinuity.observeGatewayIdentity(identity)
+            if authContinuity.generation != previousGeneration {
+                await notifyAuthContinuityMutation()
+            }
+            return authContinuity.snapshot
+        }
+    }
+}
+
+private extension AuthManager.Mode {
+    var authMode: AuthMode {
+        switch self {
+        case .legacy:
+            .legacy
+        case .publicOAuth:
+            .publicOAuth
+        case .gateway:
+            .gateway
+        case let .cab(backendURL):
+            .cab(backendURL: backendURL)
+        }
     }
 }

--- a/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
+++ b/Sources/Petrel/Auth/ConfidentialGatewayStrategy.swift
@@ -25,9 +25,101 @@ private struct GatewayErrorResponse: Decodable {
     let message: String?
 }
 
-private enum UnauthorizedDisposition {
+enum UnauthorizedDisposition {
     case terminal(reason: String)
     case transient(reason: String)
+}
+
+func classifyUnauthorizedGatewayResponse(_ data: Data) -> UnauthorizedDisposition {
+    if data.isEmpty {
+        return .transient(reason: "empty_body")
+    }
+
+    let responseBody = String(data: data, encoding: .utf8) ?? ""
+    let bodyLower = responseBody.lowercased()
+
+    if bodyLower.contains("invalid token audience") {
+        return .transient(reason: "invalid_audience")
+    }
+
+    let payload = try? JSONDecoder().decode(GatewayErrorResponse.self, from: data)
+    let errorCode = (payload?.error ?? "").lowercased()
+    let message = (payload?.message ?? responseBody).lowercased()
+
+    let terminalCodes: Set = [
+        "expiredtoken",
+        "invalidtoken",
+        "session_expired",
+        "invalid_session",
+        "token_refresh_failed",
+    ]
+
+    if terminalCodes.contains(errorCode) {
+        return .terminal(reason: errorCode)
+    }
+
+    if errorCode == "authenticationrequired",
+       message.contains("missing authentication session")
+    {
+        return .terminal(reason: "authentication_required_missing_session")
+    }
+
+    if message.contains("session expired")
+        || message.contains("invalid session")
+        || message.contains("please log in again")
+        || message.contains("token refresh rejected")
+    {
+        return .terminal(reason: "message_indicates_expiry")
+    }
+
+    let transientCodes: Set = [
+        "temporarilyunavailable",
+        "use_dpop_nonce",
+        "upstream_error",
+    ]
+
+    if transientCodes.contains(errorCode)
+        || message.contains("temporarily unavailable")
+        || message.contains("please retry")
+        || message.contains("timeout")
+    {
+        return .transient(reason: errorCode.isEmpty ? "transient_message" : errorCode)
+    }
+
+    return .transient(reason: "unknown_401")
+}
+
+func isTerminalGatewayUnauthorized(data: Data, request: URLRequest, gatewayURL: URL) -> Bool {
+    guard isRequestToGatewayOrigin(request, gatewayURL: gatewayURL) else { return false }
+    if case .terminal = classifyUnauthorizedGatewayResponse(data) {
+        return true
+    }
+    return false
+}
+
+private func isRequestToGatewayOrigin(_ request: URLRequest, gatewayURL: URL) -> Bool {
+    guard let requestURL = request.url,
+          requestURL.scheme?.lowercased() == gatewayURL.scheme?.lowercased(),
+          requestURL.host?.lowercased() == gatewayURL.host?.lowercased()
+    else {
+        return false
+    }
+
+    return effectivePort(for: requestURL) == effectivePort(for: gatewayURL)
+}
+
+private func effectivePort(for url: URL) -> Int? {
+    if let port = url.port {
+        return port
+    }
+    switch url.scheme?.lowercased() {
+    case "http":
+        return 80
+    case "https":
+        return 443
+    default:
+        return nil
+    }
 }
 
 /// Authentication strategy that delegates auth to a confidential gateway (Nest).
@@ -276,10 +368,7 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
     ) async throws -> (Data, HTTPURLResponse) {
         // Only clear session if the 401 came from our gateway
         // 401s from other services (MLS, Bluesky API) shouldn't invalidate gateway session
-        if let host = request.url?.host,
-           let gatewayHost = gatewayURL.host,
-           host == gatewayHost
-        {
+        if isRequestToGatewayOrigin(request, gatewayURL: gatewayURL) {
             switch classifyUnauthorizedGatewayResponse(data) {
             case let .terminal(reason):
                 logger.warning(
@@ -313,65 +402,6 @@ actor ConfidentialGatewayStrategy: AuthStrategy {
     }
 
     // MARK: - Private Helpers
-
-    private func classifyUnauthorizedGatewayResponse(_ data: Data) -> UnauthorizedDisposition {
-        if data.isEmpty {
-            return .transient(reason: "empty_body")
-        }
-
-        let responseBody = String(data: data, encoding: .utf8) ?? ""
-        let bodyLower = responseBody.lowercased()
-
-        if bodyLower.contains("invalid token audience") {
-            return .transient(reason: "invalid_audience")
-        }
-
-        let payload = try? JSONDecoder().decode(GatewayErrorResponse.self, from: data)
-        let errorCode = (payload?.error ?? "").lowercased()
-        let message = (payload?.message ?? responseBody).lowercased()
-
-        let terminalCodes: Set = [
-            "expiredtoken",
-            "invalidtoken",
-            "session_expired",
-            "invalid_session",
-            "token_refresh_failed",
-        ]
-
-        if terminalCodes.contains(errorCode) {
-            return .terminal(reason: errorCode)
-        }
-
-        if errorCode == "authenticationrequired",
-           message.contains("missing authentication session")
-        {
-            return .terminal(reason: "authentication_required_missing_session")
-        }
-
-        if message.contains("session expired")
-            || message.contains("invalid session")
-            || message.contains("please log in again")
-            || message.contains("token refresh rejected")
-        {
-            return .terminal(reason: "message_indicates_expiry")
-        }
-
-        let transientCodes: Set = [
-            "temporarilyunavailable",
-            "use_dpop_nonce",
-            "upstream_error",
-        ]
-
-        if transientCodes.contains(errorCode)
-            || message.contains("temporarily unavailable")
-            || message.contains("please retry")
-            || message.contains("timeout")
-        {
-            return .transient(reason: errorCode.isEmpty ? "transient_message" : errorCode)
-        }
-
-        return .transient(reason: "unknown_401")
-    }
 
     private func clearCurrentGatewaySession() async {
         guard let currentAccount = await accountManager.getCurrentAccount() else {

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -323,6 +323,14 @@ public actor NetworkService: NetworkServiceProtocol {
     private(set) var protectedResourceMetadata: ProtectedResourceMetadata?
     private(set) var authorizationServerMetadata: AuthorizationServerMetadata?
     private let requestDeduplicator = RequestDeduplicator()
+    private var authContinuityRevision: UInt64 = 0
+    private var authContinuityRevisionExhausted = false
+    private var authContinuityObserverProviderID: ObjectIdentifier?
+    private var authContinuityObserverInstallation: (
+        providerID: ObjectIdentifier,
+        revision: UInt64,
+        task: Task<Void, Never>
+    )?
 
     /// When true, all xrpc requests require auth and go through the gateway
     /// Gateway handles OAuth/DPoP - client just sends Bearer token
@@ -335,6 +343,105 @@ public actor NetworkService: NetworkServiceProtocol {
 
     /// Optional adapter for controlling connection routing (e.g., bypassing proxy for WebSockets)
     private var connectionPolicyAdapter: (any ConnectionPolicyAdapter)?
+
+    /// Retrieves authentication continuity without exposing provider secrets.
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot? {
+        while true {
+            let revision = authContinuityRevision
+            guard let provider = authProvider as? any AuthContinuityProviding else {
+                return nil
+            }
+
+            guard await installAuthContinuityObserverIfNeeded(for: provider, at: revision) else {
+                continue
+            }
+
+            let snapshot = await provider.authContinuitySnapshot()
+            guard isCurrentAuthContinuityProvider(provider, at: revision) else {
+                continue
+            }
+
+            if authContinuityRevisionExhausted {
+                return AuthContinuitySnapshot(did: nil, mode: snapshot.mode, generation: .max)
+            }
+            // NetworkService owns the public continuity clock so provider
+            // replacement and provider-internal mutations share one monotonic,
+            // collision-free generation domain.
+            return AuthContinuitySnapshot(
+                did: snapshot.did,
+                mode: snapshot.mode,
+                generation: revision
+            )
+        }
+    }
+
+    private func installAuthContinuityObserverIfNeeded(
+        for provider: any AuthContinuityProviding,
+        at revision: UInt64
+    ) async -> Bool {
+        let providerID = ObjectIdentifier(provider)
+        if authContinuityObserverProviderID == providerID {
+            return isCurrentAuthContinuityProvider(provider, at: revision)
+        }
+
+        let installationTask: Task<Void, Never>
+        if let installation = authContinuityObserverInstallation,
+           installation.providerID == providerID,
+           installation.revision == revision
+        {
+            installationTask = installation.task
+        } else {
+            let observer: @Sendable () async -> Void = { [weak self] in
+                await self?.markAuthContinuityMutation()
+            }
+            installationTask = Task {
+                await provider.installAuthContinuityObserver(observer)
+            }
+            authContinuityObserverInstallation = (providerID, revision, installationTask)
+        }
+        await installationTask.value
+
+        guard isCurrentAuthContinuityProvider(provider, at: revision) else {
+            clearAuthContinuityObserverInstallation(providerID: providerID, revision: revision)
+            return false
+        }
+        authContinuityObserverProviderID = providerID
+        clearAuthContinuityObserverInstallation(providerID: providerID, revision: revision)
+        return true
+    }
+
+    private func clearAuthContinuityObserverInstallation(
+        providerID: ObjectIdentifier,
+        revision: UInt64
+    ) {
+        guard authContinuityObserverInstallation?.providerID == providerID,
+              authContinuityObserverInstallation?.revision == revision
+        else {
+            return
+        }
+        authContinuityObserverInstallation = nil
+    }
+
+    private func isCurrentAuthContinuityProvider(
+        _ provider: any AuthContinuityProviding,
+        at revision: UInt64
+    ) -> Bool {
+        guard authContinuityRevision == revision,
+              let currentProvider = authProvider as? any AuthContinuityProviding
+        else {
+            return false
+        }
+        return currentProvider === provider
+    }
+
+    private func markAuthContinuityMutation() {
+        guard !authContinuityRevisionExhausted else { return }
+        guard authContinuityRevision < .max else {
+            authContinuityRevisionExhausted = true
+            return
+        }
+        authContinuityRevision += 1
+    }
 
     /// Endpoints that go directly to PDS and should never be proxied
     private let neverProxyEndpoints: Set<String> = [
@@ -525,8 +632,23 @@ public actor NetworkService: NetworkServiceProtocol {
 
     /// Sets the authentication provider for authenticated requests
     /// - Parameter provider: The authentication provider
-    public func setAuthenticationProvider(_ provider: AuthenticationProvider) {
+    public func setAuthenticationProvider(_ provider: AuthenticationProvider) async {
+        if let continuityProvider = provider as? any AuthContinuityProviding,
+           let currentProvider = authProvider as? any AuthContinuityProviding,
+           currentProvider === continuityProvider
+        {
+            let revision = authContinuityRevision
+            _ = await installAuthContinuityObserverIfNeeded(for: continuityProvider, at: revision)
+            return
+        }
+
         authProvider = provider
+        authContinuityObserverProviderID = nil
+        markAuthContinuityMutation()
+        if let continuityProvider = provider as? any AuthContinuityProviding {
+            let revision = authContinuityRevision
+            _ = await installAuthContinuityObserverIfNeeded(for: continuityProvider, at: revision)
+        }
     }
 
     /// Sets the connection policy adapter for controlling connection routing

--- a/Sources/Petrel/Storage/KeychainStorage.swift
+++ b/Sources/Petrel/Storage/KeychainStorage.swift
@@ -12,10 +12,43 @@
 #endif
 import Foundation
 
+private actor AuthContinuityMutationHub {
+    struct Scope: Hashable {
+        let namespace: String
+        let accessGroup: String?
+    }
+
+    static let shared = AuthContinuityMutationHub()
+
+    private var observers: [Scope: [UUID: @Sendable () async -> Void]] = [:]
+
+    func replaceObserver(
+        _ previousToken: UUID?,
+        for scope: Scope,
+        observer: @escaping @Sendable () async -> Void
+    ) -> UUID {
+        if let previousToken {
+            observers[scope]?.removeValue(forKey: previousToken)
+        }
+        let token = UUID()
+        observers[scope, default: [:]][token] = observer
+        return token
+    }
+
+    func callbacks(for scope: Scope) -> [@Sendable () async -> Void] {
+        Array(observers[scope, default: [:]].values)
+    }
+}
+
 /// A centralized storage layer for securely storing all persistent data using the keychain.
 public actor KeychainStorage {
     let namespace: String
     private let accessGroup: String?
+    private var authContinuityObserverToken: UUID?
+
+    private var authContinuityScope: AuthContinuityMutationHub.Scope {
+        AuthContinuityMutationHub.Scope(namespace: namespace, accessGroup: accessGroup)
+    }
 
     /// Initializes a new KeychainStorage instance.
     /// - Parameters:
@@ -29,6 +62,22 @@ public actor KeychainStorage {
         self.accessGroup = accessGroup
         KeychainManager.configureDefaultAccessGroup(accessGroup)
         KeychainManager.configureAccessibility(accessibility)
+    }
+
+    func setAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        let scope = authContinuityScope
+        authContinuityObserverToken = await AuthContinuityMutationHub.shared.replaceObserver(
+            authContinuityObserverToken,
+            for: scope,
+            observer: observer
+        )
+    }
+
+    private func notifyAuthContinuityMutation() async {
+        let callbacks = await AuthContinuityMutationHub.shared.callbacks(for: authContinuityScope)
+        for callback in callbacks {
+            await callback()
+        }
     }
 
     // MARK: - Account Management
@@ -236,7 +285,14 @@ public actor KeychainStorage {
     public func saveCurrentDID(_ did: String) async throws {
         let key = makeKey("currentDID")
         let data = did.data(using: .utf8) ?? Data()
-        try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+        await notifyAuthContinuityMutation()
+        do {
+            try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
     }
 
     /// Retrieves the current DID from the keychain.
@@ -258,7 +314,14 @@ public actor KeychainStorage {
         let key = makeKey("gatewaySession", did: did)
         let data = session.data(using: .utf8) ?? Data()
         LogManager.logInfo("KeychainStorage - Saving gateway session with key: \(namespace).\(key) for DID: \(did.prefix(20))...")
-        try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+        await notifyAuthContinuityMutation()
+        do {
+            try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
         LogManager.logInfo("KeychainStorage - Successfully saved gateway session for DID: \(did.prefix(20))...")
     }
 
@@ -284,7 +347,14 @@ public actor KeychainStorage {
     /// Deletes the gateway session for a specific account
     func deleteGatewaySession(for did: String) async throws {
         let key = makeKey("gatewaySession", did: did)
-        try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
+        await notifyAuthContinuityMutation()
+        do {
+            try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
         LogManager.logDebug("KeychainStorage - Deleted gateway session for DID: \(did.prefix(20))...")
     }
 
@@ -342,7 +412,14 @@ public actor KeychainStorage {
     func saveGatewaySession(_ session: String) async throws {
         let key = makeKey("gatewaySession")
         let data = session.data(using: .utf8) ?? Data()
-        try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+        await notifyAuthContinuityMutation()
+        do {
+            try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
     }
 
     @available(*, deprecated, message: "Use getGatewaySession(for:) for multi-account support")
@@ -359,7 +436,14 @@ public actor KeychainStorage {
     @available(*, deprecated, message: "Use deleteGatewaySession(for:) for multi-account support")
     func deleteGatewaySession() async throws {
         let key = makeKey("gatewaySession")
-        try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
+        await notifyAuthContinuityMutation()
+        do {
+            try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
+            await notifyAuthContinuityMutation()
+        } catch {
+            await notifyAuthContinuityMutation()
+            throw error
+        }
     }
 
     // MARK: - Session Management

--- a/Tests/PetrelTests/AuthContinuityTests.swift
+++ b/Tests/PetrelTests/AuthContinuityTests.swift
@@ -1,0 +1,540 @@
+import Foundation
+@testable import Petrel
+import XCTest
+
+final class AuthContinuityTests: XCTestCase {
+    private let did = "did:plc:authcontinuity"
+    private let gatewayURL = URL(string: "https://gateway.example")!
+
+    private func makeClient(namespace: String) async throws -> (ATProtoClient, KeychainStorage) {
+        let storage = KeychainStorage(namespace: namespace)
+        let client = try await ATProtoClient(
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            namespace: namespace,
+            authMode: .gateway,
+            gatewayURL: gatewayURL
+        )
+        return (client, storage)
+    }
+
+    private func install(
+        session: String,
+        storage: KeychainStorage,
+        client: ATProtoClient
+    ) async throws {
+        let account = Account(
+            did: did,
+            handle: "continuity.example",
+            pdsURL: gatewayURL
+        )
+        try await storage.saveAccount(account, for: did)
+        try await storage.saveGatewaySession(session, for: did)
+        try await client.switchToAccount(did: did)
+    }
+
+    func testLifecycleTransitions() async throws {
+        let namespace = "test.auth-continuity.lifecycle.\(UUID().uuidString)"
+        let (client, storage) = try await makeClient(namespace: namespace)
+
+        let initial = await client.authContinuitySnapshot()
+        XCTAssertNil(initial.did)
+        XCTAssertEqual(initial.mode, .gateway)
+
+        try await install(session: "gateway-session-one", storage: storage, client: client)
+        let installed = await client.authContinuitySnapshot()
+        XCTAssertEqual(installed.did, did)
+        XCTAssertEqual(installed.mode, .gateway)
+        XCTAssertGreaterThan(installed.generation, initial.generation)
+
+        try await storage.saveGatewaySession("gateway-session-two", for: did)
+        let replaced = await client.authContinuitySnapshot()
+        XCTAssertEqual(replaced.did, did)
+        XCTAssertGreaterThan(replaced.generation, installed.generation)
+
+        try await storage.deleteGatewaySession(for: did)
+        let cleared = await client.authContinuitySnapshot()
+        XCTAssertNil(cleared.did)
+        XCTAssertGreaterThan(cleared.generation, replaced.generation)
+
+        try await storage.saveGatewaySession("gateway-session-three", for: did)
+        let reinstalled = await client.authContinuitySnapshot()
+        XCTAssertEqual(reinstalled.did, did)
+        XCTAssertGreaterThan(reinstalled.generation, cleared.generation)
+
+        try await client.logout()
+        let loggedOut = await client.authContinuitySnapshot()
+        XCTAssertNil(loggedOut.did)
+        XCTAssertGreaterThan(loggedOut.generation, reinstalled.generation)
+
+        try await client.switchAuthMode(.legacy)
+        let switched = await client.authContinuitySnapshot()
+        XCTAssertNil(switched.did)
+        XCTAssertEqual(switched.mode, .legacy)
+        XCTAssertGreaterThan(switched.generation, loggedOut.generation)
+    }
+
+    func testSnapshotIsNonSecret() async throws {
+        let namespace = "test.auth-continuity.nonsecret.\(UUID().uuidString)"
+        let (client, storage) = try await makeClient(namespace: namespace)
+        let secret = "gateway-session-super-secret"
+        try await install(session: secret, storage: storage, client: client)
+
+        let snapshot = await client.authContinuitySnapshot()
+        let mirror = Mirror(reflecting: snapshot)
+        let labels = Set(mirror.children.compactMap(\.label))
+        let renderedValues = mirror.children.map { String(describing: $0.value) }.joined(separator: "|")
+
+        XCTAssertEqual(labels, ["did", "mode", "generation"])
+        XCTAssertFalse(renderedValues.contains(secret))
+        XCTAssertFalse(renderedValues.lowercased().contains("token"))
+        XCTAssertFalse(renderedValues.lowercased().contains("key"))
+    }
+
+    func testConcurrentReadsAndUpdates() async throws {
+        let namespace = "test.auth-continuity.concurrent.\(UUID().uuidString)"
+        let (client, storage) = try await makeClient(namespace: namespace)
+        try await install(session: "gateway-session-initial", storage: storage, client: client)
+        let initial = await client.authContinuitySnapshot()
+        let expectedDID = did
+
+        let observed = await withTaskGroup(of: AuthContinuitySnapshot.self) { group in
+            for index in 0 ..< 24 {
+                group.addTask {
+                    if index.isMultiple(of: 3) {
+                        try? await storage.saveGatewaySession("gateway-session-\(index)", for: expectedDID)
+                    }
+                    return await client.authContinuitySnapshot()
+                }
+            }
+
+            var snapshots: [AuthContinuitySnapshot] = []
+            for await snapshot in group {
+                snapshots.append(snapshot)
+            }
+            return snapshots
+        }
+
+        let final = await client.authContinuitySnapshot()
+        XCTAssertEqual(final.did, did)
+        XCTAssertGreaterThan(final.generation, initial.generation)
+        XCTAssertTrue(observed.allSatisfy { $0.generation >= initial.generation })
+        XCTAssertTrue(observed.allSatisfy { $0.mode == .gateway })
+    }
+
+    func testRefreshStyleReplacementInvalidates() async throws {
+        let namespace = "test.auth-continuity.refresh.\(UUID().uuidString)"
+        let (client, storage) = try await makeClient(namespace: namespace)
+        try await install(session: "gateway-session-before-refresh", storage: storage, client: client)
+        let before = await client.authContinuitySnapshot()
+
+        // Persistence is a security boundary: even an equal-value rewrite must
+        // advance continuity so an unobserved A→B→A sequence cannot compare equal.
+        try await storage.saveGatewaySession("gateway-session-before-refresh", for: did)
+        let sameSession = await client.authContinuitySnapshot()
+        XCTAssertEqual(sameSession.did, before.did)
+        XCTAssertGreaterThan(sameSession.generation, before.generation)
+
+        // Models a future gateway refresh path replacing the opaque session while
+        // retaining the same principal and ATProtoClient instance.
+        try await storage.saveGatewaySession("gateway-session-after-refresh", for: did)
+        let after = await client.authContinuitySnapshot()
+
+        XCTAssertEqual(after.did, before.did)
+        XCTAssertGreaterThan(after.generation, before.generation)
+    }
+
+    func testRoundTripStorageMutationsAdvancePublicGeneration() async throws {
+        let namespace = "test.auth-continuity.round-trip.\(UUID().uuidString)"
+        let (client, storage) = try await makeClient(namespace: namespace)
+        try await install(session: "gateway-session-a", storage: storage, client: client)
+        let beforeSessionRoundTrip = await client.authContinuitySnapshot()
+
+        try await storage.saveGatewaySession("gateway-session-b", for: did)
+        try await storage.saveGatewaySession("gateway-session-a", for: did)
+        let afterSessionRoundTrip = await client.authContinuitySnapshot()
+
+        XCTAssertEqual(afterSessionRoundTrip.did, beforeSessionRoundTrip.did)
+        XCTAssertGreaterThan(afterSessionRoundTrip.generation, beforeSessionRoundTrip.generation)
+
+        let otherDID = "did:plc:authcontinuity-other"
+        try await storage.saveGatewaySession("gateway-session-other", for: otherDID)
+        let beforeDIDRoundTrip = await client.authContinuitySnapshot()
+
+        try await storage.saveCurrentDID(otherDID)
+        try await storage.saveCurrentDID(did)
+        let afterDIDRoundTrip = await client.authContinuitySnapshot()
+
+        XCTAssertEqual(afterDIDRoundTrip.did, beforeDIDRoundTrip.did)
+        XCTAssertGreaterThan(afterDIDRoundTrip.generation, beforeDIDRoundTrip.generation)
+    }
+
+    func testTerminalGatewayUnauthorizedClassification() throws {
+        let gatewayRequest = URLRequest(url: gatewayURL.appendingPathComponent("xrpc/example"))
+        let otherRequest = try URLRequest(url: XCTUnwrap(URL(string: "https://pds.example/xrpc/example")))
+        let wrongPortRequest = try URLRequest(url: XCTUnwrap(URL(string: "https://gateway.example:8443/xrpc/example")))
+        let wrongSchemeRequest = try URLRequest(url: XCTUnwrap(URL(string: "http://gateway.example/xrpc/example")))
+        let terminal = Data(#"{"error":"invalid_session"}"#.utf8)
+        let transient = Data(#"{"error":"temporarilyUnavailable"}"#.utf8)
+
+        XCTAssertTrue(isTerminalGatewayUnauthorized(
+            data: terminal,
+            request: gatewayRequest,
+            gatewayURL: gatewayURL
+        ))
+        XCTAssertFalse(isTerminalGatewayUnauthorized(
+            data: transient,
+            request: gatewayRequest,
+            gatewayURL: gatewayURL
+        ))
+        XCTAssertFalse(isTerminalGatewayUnauthorized(
+            data: terminal,
+            request: otherRequest,
+            gatewayURL: gatewayURL
+        ))
+        XCTAssertFalse(isTerminalGatewayUnauthorized(
+            data: terminal,
+            request: wrongPortRequest,
+            gatewayURL: gatewayURL
+        ))
+        XCTAssertFalse(isTerminalGatewayUnauthorized(
+            data: terminal,
+            request: wrongSchemeRequest,
+            gatewayURL: gatewayURL
+        ))
+    }
+
+    func testUnauthorizedResponseContinuityWiring() async throws {
+        let namespace = "test.auth-continuity.unauthorized.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        let accountManager = MockAccountManager(account: account)
+        try await storage.saveGatewaySession("gateway-session", for: did)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: storage,
+            accountManager: accountManager,
+            networkService: NetworkService(baseURL: gatewayURL),
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        let requestURL = gatewayURL.appendingPathComponent("xrpc/example")
+        let request = URLRequest(url: requestURL)
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: requestURL,
+            statusCode: 401,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        let before = await manager.authContinuitySnapshot()
+        let transient = Data(#"{"error":"temporarilyUnavailable"}"#.utf8)
+        do {
+            _ = try await manager.handleUnauthorizedResponse(response, data: transient, for: request)
+            XCTFail("Expected transient gateway authentication error")
+        } catch {
+            XCTAssertTrue(error is ConfidentialGatewayStrategy.GatewayError)
+        }
+        let afterTransient = await manager.authContinuitySnapshot()
+        XCTAssertEqual(afterTransient, before)
+
+        let terminal = Data(#"{"error":"invalid_session"}"#.utf8)
+        do {
+            _ = try await manager.handleUnauthorizedResponse(response, data: terminal, for: request)
+            XCTFail("Expected terminal gateway authentication error")
+        } catch {
+            XCTAssertTrue(error is ConfidentialGatewayStrategy.GatewayError)
+        }
+        let after = await manager.authContinuitySnapshot()
+        XCTAssertNil(after.did)
+        XCTAssertGreaterThan(after.generation, before.generation)
+    }
+
+    func testGenerationExhaustionFailsClosed() {
+        var state = AuthContinuityState(
+            mode: .gateway,
+            generation: .max,
+            observedGatewayIdentity: .init(did: did, session: "secret")
+        )
+
+        state.invalidate()
+        let first = state.snapshot
+        state.invalidate()
+        let second = state.snapshot
+
+        XCTAssertEqual(first, AuthContinuitySnapshot(did: nil, mode: .gateway, generation: .max))
+        XCTAssertEqual(second, first)
+        XCTAssertTrue(state.isExhausted)
+    }
+
+    func testNetworkSnapshotRetriesWhenReplacementCompletesDuringProviderAwait() async {
+        let gate = SnapshotInterleavingGate()
+        let old = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let new = AuthContinuitySnapshot(
+            did: "did:plc:authcontinuity-replacement",
+            mode: .gateway,
+            generation: 8
+        )
+        let provider = InterleavingContinuityProvider(snapshot: old, gate: gate)
+        let network = NetworkService(baseURL: gatewayURL)
+        await network.setAuthenticationProvider(provider)
+
+        let result = await withTaskGroup(of: AuthContinuitySnapshot?.self) { group in
+            group.addTask {
+                await network.authContinuitySnapshot()
+            }
+            group.addTask {
+                await gate.waitUntilCaptured()
+                await provider.replaceSnapshot(with: new)
+                await gate.releaseSnapshot()
+                return nil
+            }
+
+            var observed: AuthContinuitySnapshot?
+            for await value in group where value != nil {
+                observed = value
+            }
+            return observed
+        }
+
+        XCTAssertEqual(result?.did, new.did)
+        XCTAssertEqual(result?.mode, new.mode)
+        XCTAssertGreaterThan(result?.generation ?? 0, 1)
+    }
+
+    func testNetworkSnapshotRetriesWhenProviderChangesDuringObserverInstall() async {
+        let gate = SnapshotInterleavingGate()
+        let old = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let new = AuthContinuitySnapshot(
+            did: "did:plc:authcontinuity-replacement",
+            mode: .gateway,
+            generation: 8
+        )
+        let oldProvider = InstallInterleavingContinuityProvider(snapshot: old, installGate: gate)
+        let newProvider = InstallInterleavingContinuityProvider(snapshot: new)
+        let network = NetworkService(baseURL: gatewayURL, authService: oldProvider)
+
+        let result = await withTaskGroup(of: AuthContinuitySnapshot?.self) { group in
+            group.addTask {
+                await network.authContinuitySnapshot()
+            }
+            group.addTask {
+                await gate.waitUntilCaptured()
+                await network.setAuthenticationProvider(newProvider)
+                await gate.releaseSnapshot()
+                return nil
+            }
+
+            var observed: AuthContinuitySnapshot?
+            for await value in group where value != nil {
+                observed = value
+            }
+            return observed
+        }
+
+        XCTAssertEqual(result?.did, new.did)
+        XCTAssertEqual(result?.mode, new.mode)
+        XCTAssertGreaterThan(result?.generation ?? 0, 0)
+    }
+
+    func testSettingSameProviderDoesNotReinstallContinuityObserver() async {
+        let snapshot = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let provider = InstallInterleavingContinuityProvider(snapshot: snapshot)
+        let network = NetworkService(baseURL: gatewayURL)
+
+        await network.setAuthenticationProvider(provider)
+        let before = await network.authContinuitySnapshot()
+        await network.setAuthenticationProvider(provider)
+        let after = await network.authContinuitySnapshot()
+
+        let installCount = await provider.installCount
+        XCTAssertEqual(installCount, 1)
+        XCTAssertEqual(after, before)
+    }
+
+    func testProviderReplacementAdvancesPublicGenerationWhenSnapshotsMatch() async throws {
+        let providerSnapshot = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let firstProvider = InstallInterleavingContinuityProvider(snapshot: providerSnapshot)
+        let secondProvider = InstallInterleavingContinuityProvider(snapshot: providerSnapshot)
+        let network = NetworkService(baseURL: gatewayURL)
+
+        await network.setAuthenticationProvider(firstProvider)
+        let beforeValue = await network.authContinuitySnapshot()
+        let before = try XCTUnwrap(beforeValue)
+
+        await network.setAuthenticationProvider(secondProvider)
+        let afterValue = await network.authContinuitySnapshot()
+        let after = try XCTUnwrap(afterValue)
+
+        XCTAssertEqual(after.did, before.did)
+        XCTAssertEqual(after.mode, before.mode)
+        XCTAssertGreaterThan(after.generation, before.generation)
+    }
+
+    func testKeychainSecurityMutationsSignalBeforeAndAfterPersistence() async throws {
+        let namespace = "test.auth-continuity.signals.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let recorder = ContinuitySignalRecorder()
+        await storage.setAuthContinuityObserver {
+            await recorder.record()
+        }
+
+        try await storage.saveCurrentDID(did)
+        let afterCurrentDID = await recorder.count
+        XCTAssertEqual(afterCurrentDID, 2)
+
+        try await storage.saveGatewaySession("gateway-session", for: did)
+        let afterSessionSave = await recorder.count
+        XCTAssertEqual(afterSessionSave, 4)
+
+        try await storage.deleteGatewaySession(for: did)
+        let afterSessionDelete = await recorder.count
+        XCTAssertEqual(afterSessionDelete, 6)
+    }
+}
+
+private actor SnapshotInterleavingGate {
+    private var didCapture = false
+    private var captureWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func captureAndWaitForRelease() async {
+        didCapture = true
+        let waiters = captureWaiters
+        captureWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilCaptured() async {
+        if didCapture { return }
+        await withCheckedContinuation { continuation in
+            captureWaiters.append(continuation)
+        }
+    }
+
+    func releaseSnapshot() {
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}
+
+private actor ContinuitySignalRecorder {
+    private(set) var count = 0
+
+    func record() {
+        count += 1
+    }
+}
+
+private actor InterleavingContinuityProvider: AuthContinuityProviding {
+    private var snapshot: AuthContinuitySnapshot
+    private let gate: SnapshotInterleavingGate
+    private var shouldPause = true
+    private var observer: (@Sendable () async -> Void)?
+
+    init(snapshot: AuthContinuitySnapshot, gate: SnapshotInterleavingGate) {
+        self.snapshot = snapshot
+        self.gate = gate
+    }
+
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        self.observer = observer
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        let captured = snapshot
+        if shouldPause {
+            shouldPause = false
+            await gate.captureAndWaitForRelease()
+        }
+        return captured
+    }
+
+    func replaceSnapshot(with replacement: AuthContinuitySnapshot) async {
+        await observer?()
+        snapshot = replacement
+        await observer?()
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        request
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        (request, AuthContext(did: nil, jkt: nil))
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        .stillValid
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for _: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        (data, response)
+    }
+
+    func updateDPoPNonce(for _: URL, from _: [String: String], did _: String?, jkt _: String?) async {}
+}
+
+private actor InstallInterleavingContinuityProvider: AuthContinuityProviding {
+    private let snapshot: AuthContinuitySnapshot
+    private let installGate: SnapshotInterleavingGate?
+    private(set) var installCount = 0
+
+    init(snapshot: AuthContinuitySnapshot, installGate: SnapshotInterleavingGate? = nil) {
+        self.snapshot = snapshot
+        self.installGate = installGate
+    }
+
+    func installAuthContinuityObserver(_: @escaping @Sendable () async -> Void) async {
+        installCount += 1
+        if let installGate {
+            await installGate.captureAndWaitForRelease()
+        }
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        snapshot
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        request
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        (request, AuthContext(did: nil, jkt: nil))
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        .stillValid
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for _: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        (data, response)
+    }
+
+    func updateDPoPNonce(for _: URL, from _: [String: String], did _: String?, jkt _: String?) async {}
+}


### PR DESCRIPTION
## Summary
- expose an actor-isolated, non-secret `AuthContinuitySnapshot` for MLS enrollment continuity
- use one checked NetworkService public generation domain for genuine provider replacement plus provider/storage/observation mutations
- version Keychain/session mutations across every storage instance sharing a namespace/access group
- validate provider identity plus revision across every suspension, with atomic observer replacement and single-flight installation
- fail closed on generation exhaustion and terminal exact-origin authentication invalidation
- add deterministic tests for identical-snapshot provider replacement, session/DID A→B→A, account switching, observer-install overlap, and mutation races

## Security invariant
A same-DID gateway session, DID, keychain, or authentication-provider replacement must advance public continuity before an MLS enrollment operation can accept post-suspension evidence. Identical-provider assignment is stable. Snapshots contain no bearer, DPoP, key, or session secret.

## Verification
- focused continuity tests: 13/13
- full `swift test`: 30 XCTest + 134 Swift Testing
- `swift build`
- SwiftFormat lint: 0/6
- independent adversarial re-review after automated and integration feedback: APPROVE