### PR TITLE
Serialize exact authentication continuity transactions

### DIFF
--- a/Sources/Petrel/Auth/AuthContinuity.swift
+++ b/Sources/Petrel/Auth/AuthContinuity.swift
@@ -30,9 +30,22 @@ public struct AuthContinuitySnapshot: Equatable, Sendable {
     }
 }
 
+/// The result of executing an operation while an exact authentication
+/// continuity snapshot remains serialized against in-process mutations.
+public enum AuthContinuityTransactionResult<Value: Sendable>: Sendable {
+    case performed(Value)
+    case continuityChanged
+}
+
+enum AuthContinuityProviderSnapshot {
+    case stable(AuthContinuitySnapshot)
+    case mutationPending(mode: AuthMode)
+}
+
 protocol AuthContinuityProviding: AnyObject, AuthenticationProvider {
     func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async
     func authContinuitySnapshot() async -> AuthContinuitySnapshot
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot
 }
 
 struct GatewayAuthIdentity: Equatable {
@@ -125,6 +138,12 @@ struct AuthContinuityState {
             break
         }
     }
+
+    func wouldChangeWhenObservingGatewayIdentity(_ identity: GatewayAuthIdentity?) -> Bool {
+        guard mode == .gateway, !isExhausted else { return false }
+        guard case let .observed(previous) = observation else { return false }
+        return previous != identity
+    }
 }
 
 public extension ATProtoClient {
@@ -134,5 +153,20 @@ public extension ATProtoClient {
             return snapshot
         }
         return AuthContinuitySnapshot(did: nil, mode: authMode, generation: 0)
+    }
+
+    /// Executes a synchronous operation only while `expected` is the exact
+    /// current authentication continuity snapshot. Petrel-mediated auth
+    /// mutations cannot become observable until the operation returns.
+    ///
+    /// The operation must not block or call back into Petrel. It cannot suspend.
+    func performWithExactAuthContinuity<Value: Sendable>(
+        matching expected: AuthContinuitySnapshot,
+        _ operation: @Sendable () -> Value
+    ) async -> AuthContinuityTransactionResult<Value> {
+        await networkService.performWithExactAuthContinuity(
+            matching: expected,
+            operation
+        )
     }
 }

--- a/Sources/Petrel/Auth/AuthManager.swift
+++ b/Sources/Petrel/Auth/AuthManager.swift
@@ -54,6 +54,8 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
     private let gatewayBaseURL: URL?
     private var authContinuity: AuthContinuityState
     private var authContinuityObserver: (@Sendable () async -> Void)?
+    private var pendingAuthContinuityMutations = 0
+    private var pendingStorageMutationTickets: Set<UUID> = []
 
     /// The current authentication mode.
     private(set) var currentMode: Mode
@@ -109,12 +111,13 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
 
         // Invalidate before cancelling the old strategy because cancellation is
         // an actor suspension point and must not leave stale work authorized.
-        await invalidateAuthContinuity()
+        await beginAuthContinuityMutation()
+        defer { endAuthContinuityMutation() }
 
         // Cancel any ongoing OAuth flow before switching
         await activeStrategy.cancelOAuthFlow()
 
-        activeStrategy = try Self.createStrategy(
+        let newStrategy = try Self.createStrategy(
             mode: mode,
             storage: storage,
             accountManager: accountManager,
@@ -123,9 +126,13 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
             didResolver: didResolver,
             gatewayBaseURL: gatewayBaseURL
         )
-        currentMode = mode
+
+        // No suspension is permitted between publishing the continuity mode and
+        // the strategy that prepares requests for it. The pre-signal above has
+        // already invalidated every exact transaction based on the old mode.
         authContinuity.commitMode(mode.authMode)
-        await notifyAuthContinuityMutation()
+        activeStrategy = newStrategy
+        currentMode = mode
     }
 
     // MARK: - Strategy Factory
@@ -206,23 +213,18 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
     }
 
     func handleOAuthCallback(url: URL) async throws -> (did: String, handle: String?, pdsURL: URL) {
-        if currentMode == .gateway {
+        let tracksGatewayContinuity = currentMode == .gateway
+        if tracksGatewayContinuity {
             // The callback may install or replace an opaque gateway session.
             // Invalidate before the strategy performs its first await.
-            await invalidateAuthContinuity()
+            await beginAuthContinuityMutation()
         }
-        do {
-            let result = try await activeStrategy.handleOAuthCallback(url: url)
-            if currentMode == .gateway {
-                await notifyAuthContinuityMutation()
+        defer {
+            if tracksGatewayContinuity {
+                endAuthContinuityMutation()
             }
-            return result
-        } catch {
-            if currentMode == .gateway {
-                await notifyAuthContinuityMutation()
-            }
-            throw error
         }
+        return try await activeStrategy.handleOAuthCallback(url: url)
     }
 
     func loginWithPassword(
@@ -240,14 +242,9 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
     }
 
     func logout() async throws {
-        await invalidateAuthContinuity()
-        do {
-            try await activeStrategy.logout()
-            await notifyAuthContinuityMutation()
-        } catch {
-            await notifyAuthContinuityMutation()
-            throw error
-        }
+        await beginAuthContinuityMutation()
+        defer { endAuthContinuityMutation() }
+        try await activeStrategy.logout()
     }
 
     func cancelOAuthFlow() async {
@@ -289,32 +286,21 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
         data: Data,
         for request: URLRequest
     ) async throws -> (Data, HTTPURLResponse) {
-        if currentMode == .gateway,
-           let gatewayBaseURL,
-           isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
-        {
+        let invalidatesGatewayContinuity = currentMode == .gateway
+            && gatewayBaseURL.map {
+                isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: $0)
+            } == true
+        if invalidatesGatewayContinuity {
             // The strategy will clear the local session. Change continuity
             // before forwarding across the actor boundary.
-            await invalidateAuthContinuity()
+            await beginAuthContinuityMutation()
         }
-        do {
-            let result = try await activeStrategy.handleUnauthorizedResponse(response, data: data, for: request)
-            if currentMode == .gateway,
-               let gatewayBaseURL,
-               isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
-            {
-                await notifyAuthContinuityMutation()
+        defer {
+            if invalidatesGatewayContinuity {
+                endAuthContinuityMutation()
             }
-            return result
-        } catch {
-            if currentMode == .gateway,
-               let gatewayBaseURL,
-               isTerminalGatewayUnauthorized(data: data, request: request, gatewayURL: gatewayBaseURL)
-            {
-                await notifyAuthContinuityMutation()
-            }
-            throw error
         }
+        return try await activeStrategy.handleUnauthorizedResponse(response, data: data, for: request)
     }
 
     func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
@@ -325,33 +311,64 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
 
     func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
         authContinuityObserver = observer
-        await storage.setAuthContinuityObserver { [weak self] in
-            await self?.invalidateAuthContinuityForStorageMutation()
+        await storage.setAuthContinuityObserver { [weak self] event in
+            await self?.handleAuthContinuityStorageMutation(event)
         }
     }
 
-    private func invalidateAuthContinuity() async {
-        authContinuity.invalidate()
+    private func beginAuthContinuityMutation() async {
+        pendingAuthContinuityMutations += 1
         await notifyAuthContinuityMutation()
+        authContinuity.invalidate()
+    }
+
+    private func endAuthContinuityMutation() {
+        precondition(pendingAuthContinuityMutations > 0)
+        pendingAuthContinuityMutations -= 1
     }
 
     private func notifyAuthContinuityMutation() async {
         await authContinuityObserver?()
     }
 
-    private func invalidateAuthContinuityForStorageMutation() async {
-        authContinuity.invalidate()
-        await notifyAuthContinuityMutation()
+    func handleAuthContinuityStorageMutation(_ event: AuthContinuityStorageMutationEvent) async {
+        switch event {
+        case let .willMutate(ticket):
+            guard pendingStorageMutationTickets.insert(ticket).inserted else { return }
+            await beginAuthContinuityMutation()
+        case let .didMutate(ticket):
+            guard pendingStorageMutationTickets.remove(ticket) != nil else {
+                // This observer may have joined the mutation hub after the
+                // matching willMutate event. Conservatively invalidate without
+                // clearing any other in-flight ticket.
+                await beginAuthContinuityMutation()
+                endAuthContinuityMutation()
+                return
+            }
+            await notifyAuthContinuityMutation()
+            authContinuity.invalidate()
+            endAuthContinuityMutation()
+        }
     }
 
     func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        switch await authContinuityProviderSnapshot() {
+        case let .stable(snapshot): snapshot
+        case let .mutationPending(mode): AuthContinuitySnapshot(did: nil, mode: mode, generation: .max)
+        }
+    }
+
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
         while true {
+            guard pendingAuthContinuityMutations == 0 else {
+                return .mutationPending(mode: authContinuity.mode)
+            }
             let generation = authContinuity.generation
             let mode = authContinuity.mode
             let exhausted = authContinuity.isExhausted
 
             guard mode == .gateway, !exhausted else {
-                return authContinuity.snapshot
+                return .stable(authContinuity.snapshot)
             }
 
             // Use the versioned persistent selector rather than AccountManager's
@@ -369,7 +386,8 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
             // observations from two authentication generations or modes.
             guard authContinuity.generation == generation,
                   authContinuity.mode == mode,
-                  authContinuity.isExhausted == exhausted
+                  authContinuity.isExhausted == exhausted,
+                  pendingAuthContinuityMutations == 0
             else {
                 continue
             }
@@ -379,12 +397,22 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
             } else {
                 nil
             }
-            let previousGeneration = authContinuity.generation
-            authContinuity.observeGatewayIdentity(identity)
-            if authContinuity.generation != previousGeneration {
+            if authContinuity.wouldChangeWhenObservingGatewayIdentity(identity) {
+                pendingAuthContinuityMutations += 1
                 await notifyAuthContinuityMutation()
+                guard authContinuity.generation == generation,
+                      authContinuity.mode == mode,
+                      authContinuity.isExhausted == exhausted
+                else {
+                    endAuthContinuityMutation()
+                    continue
+                }
+                authContinuity.observeGatewayIdentity(identity)
+                endAuthContinuityMutation()
+                return .stable(authContinuity.snapshot)
             }
-            return authContinuity.snapshot
+            authContinuity.observeGatewayIdentity(identity)
+            return .stable(authContinuity.snapshot)
         }
     }
 }

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -356,9 +356,16 @@ public actor NetworkService: NetworkServiceProtocol {
                 continue
             }
 
-            let snapshot = await provider.authContinuitySnapshot()
+            let providerSnapshot = await provider.authContinuityProviderSnapshot()
             guard isCurrentAuthContinuityProvider(provider, at: revision) else {
                 continue
+            }
+
+            if case let .mutationPending(mode) = providerSnapshot {
+                return AuthContinuitySnapshot(did: nil, mode: mode, generation: .max)
+            }
+            guard case let .stable(snapshot) = providerSnapshot else {
+                return nil
             }
 
             if authContinuityRevisionExhausted {
@@ -372,6 +379,43 @@ public actor NetworkService: NetworkServiceProtocol {
                 mode: snapshot.mode,
                 generation: revision
             )
+        }
+    }
+
+    func performWithExactAuthContinuity<Value: Sendable>(
+        matching expected: AuthContinuitySnapshot,
+        _ operation: @Sendable () -> Value
+    ) async -> AuthContinuityTransactionResult<Value> {
+        while true {
+            let revision = authContinuityRevision
+            guard let provider = authProvider as? any AuthContinuityProviding else {
+                return .continuityChanged
+            }
+            guard await installAuthContinuityObserverIfNeeded(for: provider, at: revision) else {
+                continue
+            }
+
+            let providerState = await provider.authContinuityProviderSnapshot()
+            guard isCurrentAuthContinuityProvider(provider, at: revision) else {
+                continue
+            }
+            guard case let .stable(providerSnapshot) = providerState else {
+                return .continuityChanged
+            }
+            guard !authContinuityRevisionExhausted else {
+                return .continuityChanged
+            }
+            let current = AuthContinuitySnapshot(
+                did: providerSnapshot.did,
+                mode: providerSnapshot.mode,
+                generation: revision
+            )
+            guard current == expected else {
+                return .continuityChanged
+            }
+
+            // Deliberately synchronous: actor isolation is the continuity lease.
+            return .performed(operation())
         }
     }
 
@@ -436,12 +480,20 @@ public actor NetworkService: NetworkServiceProtocol {
 
     private func markAuthContinuityMutation() {
         guard !authContinuityRevisionExhausted else { return }
-        guard authContinuityRevision < .max else {
+        guard authContinuityRevision < .max - 1 else {
+            authContinuityRevision = .max
             authContinuityRevisionExhausted = true
             return
         }
         authContinuityRevision += 1
     }
+
+    #if DEBUG
+        func setAuthContinuityRevisionForTesting(_ revision: UInt64) {
+            authContinuityRevision = revision
+            authContinuityRevisionExhausted = revision == .max
+        }
+    #endif
 
     /// Endpoints that go directly to PDS and should never be proxied
     private let neverProxyEndpoints: Set<String> = [
@@ -642,9 +694,9 @@ public actor NetworkService: NetworkServiceProtocol {
             return
         }
 
+        markAuthContinuityMutation()
         authProvider = provider
         authContinuityObserverProviderID = nil
-        markAuthContinuityMutation()
         if let continuityProvider = provider as? any AuthContinuityProviding {
             let revision = authContinuityRevision
             _ = await installAuthContinuityObserverIfNeeded(for: continuityProvider, at: revision)

--- a/Sources/Petrel/Storage/KeychainStorage.swift
+++ b/Sources/Petrel/Storage/KeychainStorage.swift
@@ -12,6 +12,49 @@
 #endif
 import Foundation
 
+enum AuthContinuityStorageMutationEvent {
+    case willMutate(UUID)
+    case didMutate(UUID)
+}
+
+private actor AuthContinuityObserverMailbox {
+    private let observer: @Sendable (AuthContinuityStorageMutationEvent) async -> Void
+    private var deliveryTail: (id: UUID, task: Task<Void, Never>)?
+
+    init(observer: @escaping @Sendable (AuthContinuityStorageMutationEvent) async -> Void) {
+        self.observer = observer
+    }
+
+    func deliver(_ event: AuthContinuityStorageMutationEvent) async {
+        await deliver([event])
+    }
+
+    func deliver(_ events: [AuthContinuityStorageMutationEvent]) async {
+        guard !events.isEmpty else { return }
+
+        var previous = deliveryTail?.task
+        var finalID: UUID?
+        for event in events {
+            let predecessor = previous
+            let observer = observer
+            let id = UUID()
+            let task = Task {
+                if let predecessor {
+                    await predecessor.value
+                }
+                await observer(event)
+            }
+            deliveryTail = (id, task)
+            previous = task
+            finalID = id
+        }
+        await previous?.value
+        if deliveryTail?.id == finalID {
+            deliveryTail = nil
+        }
+    }
+}
+
 private actor AuthContinuityMutationHub {
     struct Scope: Hashable {
         let namespace: String
@@ -20,23 +63,45 @@ private actor AuthContinuityMutationHub {
 
     static let shared = AuthContinuityMutationHub()
 
-    private var observers: [Scope: [UUID: @Sendable () async -> Void]] = [:]
+    private var observers: [Scope: [UUID: AuthContinuityObserverMailbox]] = [:]
+    private var activeTickets: [Scope: [UUID]] = [:]
 
     func replaceObserver(
         _ previousToken: UUID?,
         for scope: Scope,
-        observer: @escaping @Sendable () async -> Void
-    ) -> UUID {
+        observer: @escaping @Sendable (AuthContinuityStorageMutationEvent) async -> Void
+    ) async -> UUID {
         if let previousToken {
             observers[scope]?.removeValue(forKey: previousToken)
         }
         let token = UUID()
-        observers[scope, default: [:]][token] = observer
+        let mailbox = AuthContinuityObserverMailbox(observer: observer)
+        observers[scope, default: [:]][token] = mailbox
+
+        // Registration and the active-ticket snapshot are one hub operation.
+        // Mailbox isolation preserves will-before-did ordering if completion
+        // re-enters this hub while a replay callback is suspended.
+        let replay = activeTickets[scope, default: []].map(AuthContinuityStorageMutationEvent.willMutate)
+        await mailbox.deliver(replay)
         return token
     }
 
-    func callbacks(for scope: Scope) -> [@Sendable () async -> Void] {
-        Array(observers[scope, default: [:]].values)
+    func beginMutation(for scope: Scope) async -> UUID {
+        let ticket = UUID()
+        activeTickets[scope, default: []].append(ticket)
+        let mailboxes = Array(observers[scope, default: [:]].values)
+        for mailbox in mailboxes {
+            await mailbox.deliver(.willMutate(ticket))
+        }
+        return ticket
+    }
+
+    func endMutation(_ ticket: UUID, for scope: Scope) async {
+        activeTickets[scope, default: []].removeAll { $0 == ticket }
+        let mailboxes = Array(observers[scope, default: [:]].values)
+        for mailbox in mailboxes {
+            await mailbox.deliver(.didMutate(ticket))
+        }
     }
 }
 
@@ -64,7 +129,9 @@ public actor KeychainStorage {
         KeychainManager.configureAccessibility(accessibility)
     }
 
-    func setAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+    func setAuthContinuityObserver(
+        _ observer: @escaping @Sendable (AuthContinuityStorageMutationEvent) async -> Void
+    ) async {
         let scope = authContinuityScope
         authContinuityObserverToken = await AuthContinuityMutationHub.shared.replaceObserver(
             authContinuityObserverToken,
@@ -73,12 +140,23 @@ public actor KeychainStorage {
         )
     }
 
-    private func notifyAuthContinuityMutation() async {
-        let callbacks = await AuthContinuityMutationHub.shared.callbacks(for: authContinuityScope)
-        for callback in callbacks {
-            await callback()
-        }
+    private func beginAuthContinuityMutation() async -> UUID {
+        await AuthContinuityMutationHub.shared.beginMutation(for: authContinuityScope)
     }
+
+    private func endAuthContinuityMutation(_ ticket: UUID) async {
+        await AuthContinuityMutationHub.shared.endMutation(ticket, for: authContinuityScope)
+    }
+
+    #if DEBUG
+        func beginAuthContinuityMutationForTesting() async -> UUID {
+            await beginAuthContinuityMutation()
+        }
+
+        func endAuthContinuityMutationForTesting(_ ticket: UUID) async {
+            await endAuthContinuityMutation(ticket)
+        }
+    #endif
 
     // MARK: - Account Management
 
@@ -285,12 +363,12 @@ public actor KeychainStorage {
     public func saveCurrentDID(_ did: String) async throws {
         let key = makeKey("currentDID")
         let data = did.data(using: .utf8) ?? Data()
-        await notifyAuthContinuityMutation()
+        let continuityTicket = await beginAuthContinuityMutation()
         do {
             try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
         } catch {
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
             throw error
         }
     }
@@ -314,12 +392,12 @@ public actor KeychainStorage {
         let key = makeKey("gatewaySession", did: did)
         let data = session.data(using: .utf8) ?? Data()
         LogManager.logInfo("KeychainStorage - Saving gateway session with key: \(namespace).\(key) for DID: \(did.prefix(20))...")
-        await notifyAuthContinuityMutation()
+        let continuityTicket = await beginAuthContinuityMutation()
         do {
             try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
         } catch {
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
             throw error
         }
         LogManager.logInfo("KeychainStorage - Successfully saved gateway session for DID: \(did.prefix(20))...")
@@ -347,12 +425,12 @@ public actor KeychainStorage {
     /// Deletes the gateway session for a specific account
     func deleteGatewaySession(for did: String) async throws {
         let key = makeKey("gatewaySession", did: did)
-        await notifyAuthContinuityMutation()
+        let continuityTicket = await beginAuthContinuityMutation()
         do {
             try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
         } catch {
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
             throw error
         }
         LogManager.logDebug("KeychainStorage - Deleted gateway session for DID: \(did.prefix(20))...")
@@ -412,12 +490,12 @@ public actor KeychainStorage {
     func saveGatewaySession(_ session: String) async throws {
         let key = makeKey("gatewaySession")
         let data = session.data(using: .utf8) ?? Data()
-        await notifyAuthContinuityMutation()
+        let continuityTicket = await beginAuthContinuityMutation()
         do {
             try await KeychainManager.storeAsync(key: key, value: data, namespace: namespace, accessGroup: accessGroup)
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
         } catch {
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
             throw error
         }
     }
@@ -436,12 +514,12 @@ public actor KeychainStorage {
     @available(*, deprecated, message: "Use deleteGatewaySession(for:) for multi-account support")
     func deleteGatewaySession() async throws {
         let key = makeKey("gatewaySession")
-        await notifyAuthContinuityMutation()
+        let continuityTicket = await beginAuthContinuityMutation()
         do {
             try await KeychainManager.deleteAsync(key: key, namespace: namespace, accessGroup: accessGroup)
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
         } catch {
-            await notifyAuthContinuityMutation()
+            await endAuthContinuityMutation(continuityTicket)
             throw error
         }
     }

--- a/Tests/PetrelTests/AuthContinuityTests.swift
+++ b/Tests/PetrelTests/AuthContinuityTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 @testable import Petrel
 import XCTest
 
@@ -258,6 +261,354 @@ final class AuthContinuityTests: XCTestCase {
         XCTAssertGreaterThan(after.generation, before.generation)
     }
 
+    func testSwitchModeNeverAuthorizesNewModeUnderOldContinuity() async throws {
+        let namespace = "test.auth-continuity.switch-mode-ordering.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let network = NetworkService(baseURL: gatewayURL)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: storage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        await network.setAuthenticationProvider(manager)
+        let expectedValue = await network.authContinuitySnapshot()
+        let expected = try XCTUnwrap(expectedValue)
+        let probe = SwitchModeObserverProbe()
+
+        // Replace NetworkService's observer with a deliberately re-entrant one.
+        // If switchMode publishes the strategy/currentMode before committing the
+        // continuity mode, its second notification can still authorize `expected`.
+        await manager.installAuthContinuityObserver {
+            let invocation = await probe.beginInvocation()
+            guard invocation > 1 else { return }
+
+            let exposedMode = await manager.currentMode
+            let exposedSnapshot = await manager.authContinuitySnapshot()
+            let transaction = await network.performWithExactAuthContinuity(matching: expected) {
+                true
+            }
+            await probe.recordReentrantObservation(
+                mode: exposedMode,
+                snapshot: exposedSnapshot,
+                transaction: transaction
+            )
+        }
+
+        try await manager.switchMode(.legacy)
+
+        let invocationCount = await probe.invocationCount
+        let reentrantObservation = await probe.reentrantObservation
+        XCTAssertEqual(invocationCount, 1)
+        XCTAssertNil(reentrantObservation)
+        let final = await manager.authContinuitySnapshot()
+        let currentMode = await manager.currentMode
+        XCTAssertEqual(final.mode, AuthMode.legacy)
+        XCTAssertEqual(currentMode, AuthManager.Mode.legacy)
+    }
+
+    func testExactTransactionRejectsProviderWhilePreSignalIsPending() async throws {
+        let namespace = "test.auth-continuity.pending-pre-signal.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let network = NetworkService(baseURL: gatewayURL)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: storage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        let gate = SnapshotInterleavingGate()
+        let provider = HeldPreSignalContinuityProvider(provider: manager, gate: gate)
+        await network.setAuthenticationProvider(provider)
+        let beforeValue = await network.authContinuitySnapshot()
+        let before = try XCTUnwrap(beforeValue)
+
+        let switchTask = Task { try await manager.switchMode(.legacy) }
+        await gate.waitUntilCaptured()
+
+        // The observer has advanced NetworkService's revision, while the held
+        // provider mutation has not yet changed its DID/mode/strategy state.
+        let pendingValue = await network.authContinuitySnapshot()
+        let pending = try XCTUnwrap(pendingValue)
+        let callbackRan = LockedContinuityFlag()
+        let transaction = await network.performWithExactAuthContinuity(matching: pending) {
+            callbackRan.set()
+            return true
+        }
+
+        await gate.releaseSnapshot()
+        try await switchTask.value
+
+        XCTAssertNotEqual(pending, before)
+        XCTAssertEqual(pending.generation, UInt64.max)
+        XCTAssertFalse(callbackRan.value)
+        if case .performed = transaction {
+            XCTFail("A pending provider mutation must never authorize a callback")
+        }
+
+        let afterValue = await network.authContinuitySnapshot()
+        let after = try XCTUnwrap(afterValue)
+        XCTAssertEqual(after.mode, .legacy)
+        let stableTransaction = await network.performWithExactAuthContinuity(matching: after) { true }
+        guard case let .performed(value) = stableTransaction else {
+            return XCTFail("The completed mutation should expose a stable exact snapshot")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func testOverlappingStorageMutationTicketsRemainPendingUntilAllComplete() async throws {
+        let namespace = "test.auth-continuity.overlapping-storage.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let network = NetworkService(baseURL: gatewayURL)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: storage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        await network.setAuthenticationProvider(manager)
+        _ = await network.authContinuitySnapshot()
+        let first = UUID()
+        let second = UUID()
+
+        await manager.handleAuthContinuityStorageMutation(.willMutate(first))
+        await manager.handleAuthContinuityStorageMutation(.willMutate(second))
+        await manager.handleAuthContinuityStorageMutation(.didMutate(UUID()))
+        await manager.handleAuthContinuityStorageMutation(.didMutate(first))
+
+        let stillPendingValue = await network.authContinuitySnapshot()
+        let stillPending = try XCTUnwrap(stillPendingValue)
+        XCTAssertEqual(stillPending.generation, UInt64.max)
+        let rejected = await network.performWithExactAuthContinuity(matching: stillPending) { true }
+        if case .performed = rejected {
+            XCTFail("Completing one ticket must not clear another pending mutation")
+        }
+
+        await manager.handleAuthContinuityStorageMutation(.didMutate(second))
+        let stableValue = await network.authContinuitySnapshot()
+        let stable = try XCTUnwrap(stableValue)
+        XCTAssertNotEqual(stable.generation, UInt64.max)
+        let accepted = await network.performWithExactAuthContinuity(matching: stable) { true }
+        guard case let .performed(value) = accepted else {
+            return XCTFail("Completing every ticket should restore stable snapshots")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func testLateObserverInvalidatesOnUnknownStorageCompletion() async throws {
+        let namespace = "test.auth-continuity.late-storage-observer.\(UUID().uuidString)"
+        let storage = KeychainStorage(namespace: namespace)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        try await storage.saveAccount(account, for: did)
+        try await storage.saveCurrentDID(did)
+        try await storage.saveGatewaySession("gateway-session-before-refresh", for: did)
+
+        let network = NetworkService(baseURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: storage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        await network.setAuthenticationProvider(manager)
+        let beforeValue = await network.authContinuitySnapshot()
+        let before = try XCTUnwrap(beforeValue)
+        XCTAssertEqual(before.did, did)
+        let callbackRan = LockedContinuityFlag()
+
+        // Simulate joining the mutation hub after `.willMutate`: this manager
+        // receives only the completion ticket for a same-DID session refresh.
+        await manager.handleAuthContinuityStorageMutation(.didMutate(UUID()))
+        let transaction = await network.performWithExactAuthContinuity(matching: before) {
+            callbackRan.set()
+            return true
+        }
+
+        XCTAssertFalse(callbackRan.value)
+        if case .performed = transaction {
+            XCTFail("An unknown storage completion must invalidate a late observer's lease")
+        }
+        let afterValue = await network.authContinuitySnapshot()
+        let after = try XCTUnwrap(afterValue)
+        XCTAssertGreaterThan(after.generation, before.generation)
+    }
+
+    func testObserverRegisteredMidWriteImmediatelySeesPendingTicket() async throws {
+        let namespace = "test.auth-continuity.mid-write-registration.\(UUID().uuidString)"
+        let mutationStorage = KeychainStorage(namespace: namespace)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        try await mutationStorage.saveAccount(account, for: did)
+        try await mutationStorage.saveCurrentDID(did)
+        try await mutationStorage.saveGatewaySession("gateway-session-before-refresh", for: did)
+
+        // Begin before this manager's storage instance installs its observer.
+        let ticket = await mutationStorage.beginAuthContinuityMutationForTesting()
+        let managerStorage = KeychainStorage(namespace: namespace)
+        let network = NetworkService(baseURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: managerStorage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        await network.setAuthenticationProvider(manager)
+
+        let pendingValue = await network.authContinuitySnapshot()
+        let pending = try XCTUnwrap(pendingValue)
+        let callbackRan = LockedContinuityFlag()
+        let transaction = await network.performWithExactAuthContinuity(matching: pending) {
+            callbackRan.set()
+            return true
+        }
+        await mutationStorage.endAuthContinuityMutationForTesting(ticket)
+
+        XCTAssertEqual(pending.generation, UInt64.max)
+        XCTAssertFalse(callbackRan.value)
+        if case .performed = transaction {
+            XCTFail("A manager registered mid-write must not authorize exact work")
+        }
+        let stableValue = await network.authContinuitySnapshot()
+        let stable = try XCTUnwrap(stableValue)
+        XCTAssertNotEqual(stable.generation, UInt64.max)
+        let stableTransaction = await network.performWithExactAuthContinuity(matching: stable) { true }
+        guard case let .performed(value) = stableTransaction else {
+            return XCTFail("Completing the replayed ticket should restore stable snapshots")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func testCompletionRacingObserverReplayPreservesWillBeforeDid() async throws {
+        let namespace = "test.auth-continuity.replay-completion-race.\(UUID().uuidString)"
+        let mutationStorage = KeychainStorage(namespace: namespace)
+        let account = Account(did: did, handle: "continuity.example", pdsURL: gatewayURL)
+        try await mutationStorage.saveAccount(account, for: did)
+        try await mutationStorage.saveCurrentDID(did)
+        try await mutationStorage.saveGatewaySession("gateway-session", for: did)
+        let firstTicket = await mutationStorage.beginAuthContinuityMutationForTesting()
+        let secondTicket = await mutationStorage.beginAuthContinuityMutationForTesting()
+
+        let managerStorage = KeychainStorage(namespace: namespace)
+        let network = NetworkService(baseURL: gatewayURL)
+        let manager = try AuthManager(
+            mode: .gateway,
+            storage: managerStorage,
+            accountManager: MockAccountManager(account: account),
+            networkService: network,
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/client-metadata.json",
+                redirectUri: "blue.catbird:/oauth/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver(),
+            gatewayBaseURL: gatewayURL
+        )
+        let gate = SnapshotInterleavingGate()
+        let provider = HeldPreSignalContinuityProvider(provider: manager, gate: gate)
+        let installationTask = Task { await network.setAuthenticationProvider(provider) }
+        await gate.waitUntilCaptured()
+
+        let completionFinished = DispatchSemaphore(value: 0)
+        let completionTask = Task {
+            await mutationStorage.endAuthContinuityMutationForTesting(secondTicket)
+            completionFinished.signal()
+        }
+        let completedWhileReplayHeld = await waitForContinuitySemaphore(
+            completionFinished,
+            timeout: .now() + 0.05
+        )
+
+        await gate.releaseSnapshot()
+        await installationTask.value
+        await completionTask.value
+
+        XCTAssertFalse(completedWhileReplayHeld)
+        let stillPendingValue = await network.authContinuitySnapshot()
+        let stillPending = try XCTUnwrap(stillPendingValue)
+        XCTAssertEqual(stillPending.generation, UInt64.max)
+
+        await mutationStorage.endAuthContinuityMutationForTesting(firstTicket)
+        let stableValue = await network.authContinuitySnapshot()
+        let stable = try XCTUnwrap(stableValue)
+        XCTAssertNotEqual(stable.generation, UInt64.max)
+        let transaction = await network.performWithExactAuthContinuity(matching: stable) { true }
+        guard case let .performed(value) = transaction else {
+            return XCTFail("Ordered replay completion must not leave a stale pending ticket")
+        }
+        XCTAssertTrue(value)
+    }
+
+    func testPendingSentinelCannotBecomeStableLeaseAtRevisionExhaustion() async throws {
+        let network = NetworkService(baseURL: gatewayURL)
+        let stable = AuthContinuitySnapshot(did: nil, mode: .gateway, generation: 7)
+        let provider = ControllablePendingContinuityProvider(stableSnapshot: stable)
+        await network.setAuthenticationProvider(provider)
+        _ = await network.authContinuitySnapshot()
+        await network.setAuthContinuityRevisionForTesting(.max - 1)
+
+        await provider.beginPendingMutation()
+        let pendingValue = await network.authContinuitySnapshot()
+        let pending = try XCTUnwrap(pendingValue)
+        XCTAssertEqual(pending.generation, UInt64.max)
+        XCTAssertNil(pending.did)
+        XCTAssertEqual(pending.mode, .gateway)
+
+        // Complete to the exact same public DID/mode tuple. Only reserving .max
+        // and marking the public clock exhausted can keep this from matching.
+        await provider.completePendingMutation()
+
+        let callbackRan = LockedContinuityFlag()
+        let transaction = await network.performWithExactAuthContinuity(matching: pending) {
+            callbackRan.set()
+            return true
+        }
+        XCTAssertFalse(callbackRan.value)
+        if case .performed = transaction {
+            XCTFail("The reserved pending sentinel must never become a stable lease")
+        }
+        let exhaustedValue = await network.authContinuitySnapshot()
+        let exhausted = try XCTUnwrap(exhaustedValue)
+        XCTAssertEqual(exhausted.generation, UInt64.max)
+        XCTAssertNil(exhausted.did)
+    }
+
     func testGenerationExhaustionFailsClosed() {
         var state = AuthContinuityState(
             mode: .gateway,
@@ -345,6 +696,89 @@ final class AuthContinuityTests: XCTestCase {
         XCTAssertGreaterThan(result?.generation ?? 0, 0)
     }
 
+    func testExactTransactionRejectsMutationAfterProviderSnapshot() async {
+        let gate = SnapshotInterleavingGate()
+        let old = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let new = AuthContinuitySnapshot(
+            did: "did:plc:authcontinuity-mutated",
+            mode: .gateway,
+            generation: 8
+        )
+        let provider = InterleavingContinuityProvider(snapshot: old, gate: gate)
+        let network = NetworkService(baseURL: gatewayURL)
+        await network.setAuthenticationProvider(provider)
+        let expected = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 1)
+        let callbackRan = LockedContinuityFlag()
+
+        let transaction = Task {
+            await network.performWithExactAuthContinuity(matching: expected) {
+                callbackRan.set()
+                return true
+            }
+        }
+        await gate.waitUntilCaptured()
+        let mutation = Task { await provider.replaceSnapshot(with: new) }
+        await provider.waitUntilReplacementPreSignaled()
+        await gate.releaseSnapshot()
+        _ = await mutation.value
+
+        switch await transaction.value {
+        case .continuityChanged:
+            break
+        case .performed:
+            XCTFail("A changed generation must not enter the callback")
+        }
+        XCTAssertFalse(callbackRan.value)
+    }
+
+    func testExactTransactionBlocksMutationUntilSynchronousCallbackReturns() async throws {
+        let snapshot = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
+        let provider = InstallInterleavingContinuityProvider(snapshot: snapshot)
+        let network = NetworkService(baseURL: gatewayURL)
+        await network.setAuthenticationProvider(provider)
+        let expectedValue = await network.authContinuitySnapshot()
+        let expected = try XCTUnwrap(expectedValue)
+        let callbackEntered = DispatchSemaphore(value: 0)
+        let releaseCallback = DispatchSemaphore(value: 0)
+        let replacementStarted = DispatchSemaphore(value: 0)
+        let mutationFinished = DispatchSemaphore(value: 0)
+
+        let transaction = Task.detached {
+            await network.performWithExactAuthContinuity(matching: expected) {
+                callbackEntered.signal()
+                releaseCallback.wait()
+                return false
+            }
+        }
+        _ = await waitForContinuitySemaphore(callbackEntered)
+        let replacement = InstallInterleavingContinuityProvider(snapshot: snapshot)
+        let replacementTask = Task.detached {
+            replacementStarted.signal()
+            await network.setAuthenticationProvider(replacement)
+            mutationFinished.signal()
+        }
+        _ = await waitForContinuitySemaphore(replacementStarted)
+        let changedWhileCallbackHeld = await waitForContinuitySemaphore(
+            mutationFinished,
+            timeout: .now() + 0.05
+        )
+        XCTAssertFalse(changedWhileCallbackHeld)
+        releaseCallback.signal()
+
+        switch await transaction.value {
+        case let .performed(result):
+            XCTAssertFalse(result)
+        case .continuityChanged:
+            XCTFail("The callback owned the continuity lease first")
+        }
+        _ = await waitForContinuitySemaphore(mutationFinished)
+        _ = await replacementTask.value
+        let stale = await network.performWithExactAuthContinuity(matching: expected) { true }
+        if case .performed = stale {
+            XCTFail("The old generation must fail after provider replacement")
+        }
+    }
+
     func testSettingSameProviderDoesNotReinstallContinuityObserver() async {
         let snapshot = AuthContinuitySnapshot(did: did, mode: .gateway, generation: 7)
         let provider = InstallInterleavingContinuityProvider(snapshot: snapshot)
@@ -383,7 +817,7 @@ final class AuthContinuityTests: XCTestCase {
         let namespace = "test.auth-continuity.signals.\(UUID().uuidString)"
         let storage = KeychainStorage(namespace: namespace)
         let recorder = ContinuitySignalRecorder()
-        await storage.setAuthContinuityObserver {
+        await storage.setAuthContinuityObserver { _ in
             await recorder.record()
         }
 
@@ -442,11 +876,76 @@ private actor ContinuitySignalRecorder {
     }
 }
 
+private actor SwitchModeObserverProbe {
+    struct Observation {
+        let mode: AuthManager.Mode
+        let snapshot: AuthContinuitySnapshot
+        let transactionWasAuthorized: Bool
+    }
+
+    private(set) var invocationCount = 0
+    private(set) var reentrantObservation: Observation?
+
+    func beginInvocation() -> Int {
+        invocationCount += 1
+        return invocationCount
+    }
+
+    func recordReentrantObservation(
+        mode: AuthManager.Mode,
+        snapshot: AuthContinuitySnapshot,
+        transaction: AuthContinuityTransactionResult<Bool>
+    ) {
+        let transactionWasAuthorized = switch transaction {
+        case let .performed(value): value
+        case .continuityChanged: false
+        }
+        reentrantObservation = Observation(
+            mode: mode,
+            snapshot: snapshot,
+            transactionWasAuthorized: transactionWasAuthorized
+        )
+    }
+}
+
+private final class LockedContinuityFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+
+    var value: Bool {
+        lock.withLock { flag }
+    }
+
+    func set() {
+        lock.withLock { flag = true }
+    }
+}
+
+private func waitForContinuitySemaphore(
+    _ semaphore: DispatchSemaphore,
+    timeout: DispatchTime? = nil
+) async -> Bool {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            let result: DispatchTimeoutResult
+            if let timeout {
+                result = semaphore.wait(timeout: timeout)
+            } else {
+                semaphore.wait()
+                result = .success
+            }
+            continuation.resume(returning: result == .success)
+        }
+    }
+}
+
 private actor InterleavingContinuityProvider: AuthContinuityProviding {
     private var snapshot: AuthContinuitySnapshot
     private let gate: SnapshotInterleavingGate
     private var shouldPause = true
     private var observer: (@Sendable () async -> Void)?
+    private var replacementWasPreSignaled = false
+    private var replacementPreSignaledContinuation: CheckedContinuation<Void, Never>?
 
     init(snapshot: AuthContinuitySnapshot, gate: SnapshotInterleavingGate) {
         self.snapshot = snapshot
@@ -466,10 +965,24 @@ private actor InterleavingContinuityProvider: AuthContinuityProviding {
         return captured
     }
 
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
+        .stable(await authContinuitySnapshot())
+    }
+
     func replaceSnapshot(with replacement: AuthContinuitySnapshot) async {
         await observer?()
+        replacementWasPreSignaled = true
+        replacementPreSignaledContinuation?.resume()
+        replacementPreSignaledContinuation = nil
         snapshot = replacement
         await observer?()
+    }
+
+    func waitUntilReplacementPreSignaled() async {
+        guard !replacementWasPreSignaled else { return }
+        await withCheckedContinuation { continuation in
+            replacementPreSignaledContinuation = continuation
+        }
     }
 
     func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
@@ -514,6 +1027,122 @@ private actor InstallInterleavingContinuityProvider: AuthContinuityProviding {
 
     func authContinuitySnapshot() async -> AuthContinuitySnapshot {
         snapshot
+    }
+
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
+        .stable(snapshot)
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        request
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        (request, AuthContext(did: nil, jkt: nil))
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        .stillValid
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for _: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        (data, response)
+    }
+
+    func updateDPoPNonce(for _: URL, from _: [String: String], did _: String?, jkt _: String?) async {}
+}
+
+private actor HeldPreSignalContinuityProvider: AuthContinuityProviding {
+    private let provider: any AuthContinuityProviding
+    private let gate: SnapshotInterleavingGate
+    private var hasHeldSignal = false
+
+    init(provider: any AuthContinuityProviding, gate: SnapshotInterleavingGate) {
+        self.provider = provider
+        self.gate = gate
+    }
+
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        await provider.installAuthContinuityObserver { [weak self] in
+            await observer()
+            await self?.holdFirstSignal()
+        }
+    }
+
+    private func holdFirstSignal() async {
+        guard !hasHeldSignal else { return }
+        hasHeldSignal = true
+        await gate.captureAndWaitForRelease()
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        await provider.authContinuitySnapshot()
+    }
+
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
+        await provider.authContinuityProviderSnapshot()
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        try await provider.prepareAuthenticatedRequest(request)
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        try await provider.prepareAuthenticatedRequestWithContext(request)
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        try await provider.refreshTokenIfNeeded()
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for request: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        try await provider.handleUnauthorizedResponse(response, data: data, for: request)
+    }
+
+    func updateDPoPNonce(for url: URL, from headers: [String: String], did: String?, jkt: String?) async {
+        await provider.updateDPoPNonce(for: url, from: headers, did: did, jkt: jkt)
+    }
+}
+
+private actor ControllablePendingContinuityProvider: AuthContinuityProviding {
+    private let stableSnapshot: AuthContinuitySnapshot
+    private var isPending = false
+    private var observer: (@Sendable () async -> Void)?
+
+    init(stableSnapshot: AuthContinuitySnapshot) {
+        self.stableSnapshot = stableSnapshot
+    }
+
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        self.observer = observer
+    }
+
+    func beginPendingMutation() async {
+        isPending = true
+        await observer?()
+    }
+
+    func completePendingMutation() {
+        isPending = false
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        stableSnapshot
+    }
+
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
+        if isPending {
+            return .mutationPending(mode: stableSnapshot.mode)
+        }
+        return .stable(stableSnapshot)
     }
 
     func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {


### PR DESCRIPTION
## Summary
- add a public exact auth-continuity transaction on `ATProtoClient`
- pre-signal provider and credential mutations before they become observable
- serialize security-sensitive callbacks against provider replacement and generation drift

## Security invariant
A callback runs only while the exact DID, auth mode, provider, and public generation remain current. An auth mutation either advances continuity before callback admission or waits until the synchronous callback returns.

## Verification
- `swift build`
- `swift test --filter AuthContinuityTests` (15/15)
- independent architecture review: APPROVE

Required by joshlacal/CatbirdMLSCore#11 to close automated review finding P1 3574053424.