### PR TITLE
Petrel: Bind generated requests to exact auth continuity

### DIFF
--- a/Sources/Petrel/Auth/AuthContinuity.swift
+++ b/Sources/Petrel/Auth/AuthContinuity.swift
@@ -37,6 +37,73 @@ public enum AuthContinuityTransactionResult<Value: Sendable>: Sendable {
     case continuityChanged
 }
 
+final class ExactAuthGeneratedRequestScopeState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var launchClaimed = false
+    private var responseCompleted = false
+    private var continuityFailed = false
+
+    func claimLaunch() -> Bool {
+        lock.withLock {
+            guard !launchClaimed, !continuityFailed else { return false }
+            launchClaimed = true
+            return true
+        }
+    }
+
+    func failContinuity() {
+        lock.withLock { continuityFailed = true }
+    }
+
+    func completeResponse() -> Bool {
+        lock.withLock {
+            guard launchClaimed, !responseCompleted, !continuityFailed else { return false }
+            responseCompleted = true
+            return true
+        }
+    }
+
+    var completedExactlyOneResponse: Bool {
+        lock.withLock { launchClaimed && responseCompleted && !continuityFailed }
+    }
+}
+
+struct ExactAuthRequestOrigin: Equatable {
+    let scheme: String
+    let host: String
+    let effectivePort: Int
+
+    init?(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme?.lowercased() == "https",
+              let host = components.host?.lowercased(),
+              !host.isEmpty,
+              components.user == nil,
+              components.password == nil
+        else {
+            return nil
+        }
+        scheme = "https"
+        self.host = host
+        effectivePort = components.port ?? 443
+    }
+}
+
+struct ExactAuthGeneratedRequestScope {
+    let id: UUID
+    let expected: AuthContinuitySnapshot
+    let networkServiceID: UUID
+    let origin: ExactAuthRequestOrigin
+    let destinationGeneration: UUID
+    let state: ExactAuthGeneratedRequestScopeState
+}
+
+enum ExactAuthGeneratedRequestScopeContext {
+    @TaskLocal static var current: ExactAuthGeneratedRequestScope?
+}
+
+struct ExactAuthGeneratedRequestContinuityError: Error {}
+
 enum AuthContinuityProviderSnapshot {
     case stable(AuthContinuitySnapshot)
     case mutationPending(mode: AuthMode)
@@ -168,5 +235,66 @@ public extension ATProtoClient {
             matching: expected,
             operation
         )
+    }
+
+    /// Executes one directly-awaited generated API operation under an exact
+    /// authentication request scope.
+    ///
+    /// The generated operation must be awaited directly and must issue exactly
+    /// one request. Child tasks inherit the scope and remain fail-closed. Do not
+    /// escape work from `operation`; detached work has no scope and is rejected
+    /// while this scope owns the network service.
+    func performGeneratedRequestWithExactAuthContinuity<Value: Sendable>(
+        matching expected: AuthContinuitySnapshot,
+        _ operation: @Sendable () async throws -> Value
+    ) async throws -> AuthContinuityTransactionResult<Value> {
+        let serviceID = networkService.exactAuthRequestScopeServiceID
+
+        if let current = ExactAuthGeneratedRequestScopeContext.current {
+            guard current.expected == expected,
+                  current.networkServiceID == serviceID,
+                  await networkService.isExactAuthGeneratedRequestScopeActive(current)
+            else {
+                current.state.failContinuity()
+                return .continuityChanged
+            }
+
+            do {
+                let value = try await operation()
+                return await networkService.isExactAuthGeneratedRequestScopeActive(current)
+                    && current.state.completedExactlyOneResponse
+                    ? .performed(value)
+                    : .continuityChanged
+            } catch is ExactAuthGeneratedRequestContinuityError {
+                current.state.failContinuity()
+                return .continuityChanged
+            }
+        }
+
+        let state = ExactAuthGeneratedRequestScopeState()
+        guard let scope = await networkService.beginExactAuthGeneratedRequestScope(
+            id: UUID(),
+            expected: expected,
+            state: state
+        ) else {
+            return .continuityChanged
+        }
+
+        do {
+            let value = try await ExactAuthGeneratedRequestScopeContext.$current.withValue(scope) {
+                try await operation()
+            }
+            await networkService.endExactAuthGeneratedRequestScope(scope)
+            return scope.state.completedExactlyOneResponse
+                ? .performed(value)
+                : .continuityChanged
+        } catch is ExactAuthGeneratedRequestContinuityError {
+            scope.state.failContinuity()
+            await networkService.endExactAuthGeneratedRequestScope(scope)
+            return .continuityChanged
+        } catch {
+            await networkService.endExactAuthGeneratedRequestScope(scope)
+            throw error
+        }
     }
 }

--- a/Sources/Petrel/Network/HardenedURLSessionDelegate.swift
+++ b/Sources/Petrel/Network/HardenedURLSessionDelegate.swift
@@ -16,6 +16,12 @@ import Foundation
 final class HardenedURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate, @unchecked Sendable {
     private let maxRedirects = 5
     private let maxResponseSize = 10 * 1024 * 1024 // 10 MB
+    private let allowsRedirects: Bool
+
+    init(allowsRedirects: Bool = true) {
+        self.allowsRedirects = allowsRedirects
+        super.init()
+    }
 
     private actor TaskContextManager {
         private var taskContexts = [URLSessionTask: TaskContext]()
@@ -51,6 +57,11 @@ final class HardenedURLSessionDelegate: NSObject, URLSessionDelegate, URLSession
         newRequest request: URLRequest,
         completionHandler: @escaping @Sendable (URLRequest?) -> Void
     ) {
+        guard allowsRedirects else {
+            LogManager.logInfo("Rejected redirect for exact-auth request scope")
+            completionHandler(nil)
+            return
+        }
         let requestURLString = request.url?.absoluteString ?? "unknown URL"
 
         Task {

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -22,6 +22,18 @@ import Foundation
 /// With the fixed HardenedURLSessionDelegate (not implementing didReceive:),
 /// URLSession should handle decompression automatically. This is kept as a safety net.
 enum ContentDecoding {
+    static func headerValue(named name: String, in headerFields: [AnyHashable: Any]) -> String? {
+        for (key, value) in headerFields {
+            if let keyString = key as? String,
+               keyString.caseInsensitiveCompare(name) == .orderedSame,
+               let valueString = value as? String
+            {
+                return valueString
+            }
+        }
+        return nil
+    }
+
     /// Attempts to decompress data if it appears to still be compressed.
     /// Returns original data if already decompressed or decompression fails.
     static func decompressIfNeeded(_ data: Data, contentEncoding: String?) -> Data {
@@ -440,8 +452,16 @@ public actor NetworkService: NetworkServiceProtocol {
         state: ExactAuthGeneratedRequestScopeState
     ) async -> ExactAuthGeneratedRequestScope? {
         guard activeExactAuthRequestScope == nil,
-              let origin = ExactAuthRequestOrigin(baseURL),
-              await exactAuthSnapshot(matching: expected) != nil
+              let origin = ExactAuthRequestOrigin(baseURL)
+        else {
+            state.failContinuity()
+            return nil
+        }
+        let destinationGeneration = exactAuthDestinationGeneration
+        guard await exactAuthSnapshot(matching: expected) != nil,
+              activeExactAuthRequestScope == nil,
+              ExactAuthRequestOrigin(baseURL) == origin,
+              exactAuthDestinationGeneration == destinationGeneration
         else {
             state.failContinuity()
             return nil
@@ -451,7 +471,7 @@ public actor NetworkService: NetworkServiceProtocol {
             expected: expected,
             networkServiceID: exactAuthRequestScopeServiceID,
             origin: origin,
-            destinationGeneration: exactAuthDestinationGeneration,
+            destinationGeneration: destinationGeneration,
             state: state
         )
         activeExactAuthRequestScope = scope
@@ -1609,7 +1629,10 @@ public actor NetworkService: NetworkServiceProtocol {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw NetworkError.invalidResponse(description: "Received non-HTTP response")
         }
-        let contentEncoding = httpResponse.value(forHTTPHeaderField: "Content-Encoding")
+        let contentEncoding = ContentDecoding.headerValue(
+            named: "Content-Encoding",
+            in: httpResponse.allHeaderFields
+        )
         let data = ContentDecoding.decompressIfNeeded(rawData, contentEncoding: contentEncoding)
 
         guard await exactAuthSnapshot(

--- a/Sources/Petrel/Network/NetworkService.swift
+++ b/Sources/Petrel/Network/NetworkService.swift
@@ -316,6 +316,7 @@ public actor NetworkService: NetworkServiceProtocol {
     private var authProvider: AuthenticationProvider?
     private var headers: [String: String] = [:]
     private let session: URLSession
+    private let exactAuthSession: URLSession
     private let jsonEncoder = JSONEncoder()
     private let jsonDecoder = JSONDecoder()
     private let maxRetries = 3
@@ -331,6 +332,20 @@ public actor NetworkService: NetworkServiceProtocol {
         revision: UInt64,
         task: Task<Void, Never>
     )?
+    nonisolated let exactAuthRequestScopeServiceID = UUID()
+    private var activeExactAuthRequestScope: ExactAuthGeneratedRequestScope?
+    private var exactAuthDestinationGeneration = UUID()
+
+    #if DEBUG
+        private nonisolated(unsafe) static var networkTestProtocolClasses: [AnyClass]?
+        private static let networkTestProtocolClassesLock = NSLock()
+
+        static func setNetworkTestProtocolClasses(_ classes: [AnyClass]?) {
+            networkTestProtocolClassesLock.withLock {
+                networkTestProtocolClasses = classes
+            }
+        }
+    #endif
 
     /// When true, all xrpc requests require auth and go through the gateway
     /// Gateway handles OAuth/DPoP - client just sends Bearer token
@@ -419,6 +434,39 @@ public actor NetworkService: NetworkServiceProtocol {
         }
     }
 
+    func beginExactAuthGeneratedRequestScope(
+        id: UUID,
+        expected: AuthContinuitySnapshot,
+        state: ExactAuthGeneratedRequestScopeState
+    ) async -> ExactAuthGeneratedRequestScope? {
+        guard activeExactAuthRequestScope == nil,
+              let origin = ExactAuthRequestOrigin(baseURL),
+              await exactAuthSnapshot(matching: expected) != nil
+        else {
+            state.failContinuity()
+            return nil
+        }
+        let scope = ExactAuthGeneratedRequestScope(
+            id: id,
+            expected: expected,
+            networkServiceID: exactAuthRequestScopeServiceID,
+            origin: origin,
+            destinationGeneration: exactAuthDestinationGeneration,
+            state: state
+        )
+        activeExactAuthRequestScope = scope
+        return scope
+    }
+
+    func endExactAuthGeneratedRequestScope(_ scope: ExactAuthGeneratedRequestScope) {
+        guard activeExactAuthRequestScope?.id == scope.id else { return }
+        activeExactAuthRequestScope = nil
+    }
+
+    func isExactAuthGeneratedRequestScopeActive(_ scope: ExactAuthGeneratedRequestScope) -> Bool {
+        isActiveExactAuthRequestScope(scope)
+    }
+
     private func installAuthContinuityObserverIfNeeded(
         for provider: any AuthContinuityProviding,
         at revision: UInt64
@@ -478,6 +526,53 @@ public actor NetworkService: NetworkServiceProtocol {
         return currentProvider === provider
     }
 
+    private func exactAuthProvider(
+        matching expected: AuthContinuitySnapshot
+    ) async -> (provider: any AuthContinuityProviding, revision: UInt64)? {
+        let revision = authContinuityRevision
+        guard let provider = authProvider as? any AuthContinuityProviding,
+              await installAuthContinuityObserverIfNeeded(for: provider, at: revision),
+              await exactAuthSnapshot(
+                  for: provider,
+                  at: revision,
+                  matching: expected
+              )
+        else {
+            return nil
+        }
+        return (provider, revision)
+    }
+
+    private func exactAuthSnapshot(
+        matching expected: AuthContinuitySnapshot
+    ) async -> AuthContinuitySnapshot? {
+        guard await exactAuthProvider(matching: expected) != nil else { return nil }
+        return expected
+    }
+
+    private func exactAuthSnapshot(
+        for provider: any AuthContinuityProviding,
+        at revision: UInt64,
+        matching expected: AuthContinuitySnapshot
+    ) async -> Bool {
+        guard !authContinuityRevisionExhausted,
+              isCurrentAuthContinuityProvider(provider, at: revision)
+        else {
+            return false
+        }
+        let providerState = await provider.authContinuityProviderSnapshot()
+        guard isCurrentAuthContinuityProvider(provider, at: revision),
+              case let .stable(providerSnapshot) = providerState
+        else {
+            return false
+        }
+        return AuthContinuitySnapshot(
+            did: providerSnapshot.did,
+            mode: providerSnapshot.mode,
+            generation: revision
+        ) == expected
+    }
+
     private func markAuthContinuityMutation() {
         guard !authContinuityRevisionExhausted else { return }
         guard authContinuityRevision < .max - 1 else {
@@ -527,10 +622,35 @@ public actor NetworkService: NetworkServiceProtocol {
 
         config.httpMaximumConnectionsPerHost = 5
         config.httpShouldUsePipelining = true
+        #if DEBUG
+            config.protocolClasses = Self.networkTestProtocolClassesLock.withLock {
+                Self.networkTestProtocolClasses
+            }
+        #endif
 
         // Create a session with a delegate for enhanced security
         let sessionDelegate = HardenedURLSessionDelegate()
         session = URLSession(configuration: config, delegate: sessionDelegate, delegateQueue: nil)
+        let exactConfig = URLSessionConfiguration.ephemeral
+        exactConfig.timeoutIntervalForRequest = config.timeoutIntervalForRequest
+        exactConfig.timeoutIntervalForResource = config.timeoutIntervalForResource
+        exactConfig.requestCachePolicy = .reloadIgnoringLocalCacheData
+        exactConfig.httpShouldSetCookies = false
+        exactConfig.httpCookieStorage = nil
+        exactConfig.urlCredentialStorage = nil
+        exactConfig.urlCache = nil
+        exactConfig.httpMaximumConnectionsPerHost = 1
+        exactConfig.httpShouldUsePipelining = false
+        #if DEBUG
+            exactConfig.protocolClasses = Self.networkTestProtocolClassesLock.withLock {
+                Self.networkTestProtocolClasses
+            }
+        #endif
+        exactAuthSession = URLSession(
+            configuration: exactConfig,
+            delegate: HardenedURLSessionDelegate(allowsRedirects: false),
+            delegateQueue: nil
+        )
 
         // Set JSON encoder settings
         jsonEncoder.keyEncodingStrategy = .useDefaultKeys
@@ -558,6 +678,7 @@ public actor NetworkService: NetworkServiceProtocol {
     /// Sets the base URL for API requests.
     /// - Parameter url: The new base URL.
     public func setBaseURL(_ url: URL) async {
+        exactAuthDestinationGeneration = UUID()
         baseURL = url
         LogManager.logInfo("Network Service - Base URL updated to: \(url)")
     }
@@ -706,6 +827,7 @@ public actor NetworkService: NetworkServiceProtocol {
     /// Sets the connection policy adapter for controlling connection routing
     /// - Parameter adapter: The connection policy adapter
     public func setConnectionPolicyAdapter(_ adapter: (any ConnectionPolicyAdapter)?) {
+        exactAuthDestinationGeneration = UUID()
         connectionPolicyAdapter = adapter
         LogManager.logInfo("Network Service - Connection policy adapter \(adapter == nil ? "removed" : "set")")
     }
@@ -880,6 +1002,18 @@ public actor NetworkService: NetworkServiceProtocol {
     func request(_ request: URLRequest, skipTokenRefresh: Bool = false, additionalHeaders: [String: String]? = nil) async throws -> (
         Data, URLResponse
     ) {
+        if let scope = ExactAuthGeneratedRequestScopeContext.current {
+            return try await requestWithExactAuthContinuity(
+                request,
+                additionalHeaders: additionalHeaders,
+                scope: scope
+            )
+        }
+        if let activeExactAuthRequestScope {
+            activeExactAuthRequestScope.state.failContinuity()
+            throw ExactAuthGeneratedRequestContinuityError()
+        }
+
         let currentRequest = request
         var retryCount = 0
 
@@ -1399,6 +1533,121 @@ public actor NetworkService: NetworkServiceProtocol {
             "Network Service - Max retry attempts reached for \(currentRequest.url?.absoluteString ?? "Unknown URL")."
         )
         throw NetworkError.maxRetryAttemptsReached
+    }
+
+    private func requestWithExactAuthContinuity(
+        _ request: URLRequest,
+        additionalHeaders: [String: String]?,
+        scope: ExactAuthGeneratedRequestScope
+    ) async throws -> (Data, URLResponse) {
+        guard isActiveExactAuthRequestScope(scope),
+              let boundURL = request.url,
+              ExactAuthRequestOrigin(boundURL) == scope.origin,
+              request.httpBodyStream == nil,
+              !Task.isCancelled,
+              let captured = await exactAuthProvider(matching: scope.expected)
+        else {
+            scope.state.failContinuity()
+            throw ExactAuthGeneratedRequestContinuityError()
+        }
+
+        var requestToPrepare = request
+        for field in ["Authorization", "DPoP", "Cookie", "Proxy-Authorization"] {
+            requestToPrepare.setValue(nil, forHTTPHeaderField: field)
+        }
+        for (name, value) in headers {
+            guard !Self.isCredentialHeader(name) else { continue }
+            requestToPrepare.setValue(value, forHTTPHeaderField: name)
+        }
+        if let additionalHeaders {
+            for (name, value) in additionalHeaders {
+                guard !Self.isCredentialHeader(name) else { continue }
+                if name.lowercased() == "atproto-proxy",
+                   requestToPrepare.url?.host != baseURL.host
+                {
+                    continue
+                }
+                requestToPrepare.setValue(value, forHTTPHeaderField: name)
+            }
+        }
+        if let userAgent {
+            requestToPrepare.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+            requestToPrepare.setValue(userAgent, forHTTPHeaderField: "X-Catbird-Client")
+        }
+        requestToPrepare.setValue(UUID().uuidString, forHTTPHeaderField: "X-Catbird-Request-Id")
+
+        let prepared: URLRequest
+        do {
+            prepared = try await captured.provider.prepareAuthenticatedRequestWithContext(requestToPrepare).0
+        } catch {
+            scope.state.failContinuity()
+            throw ExactAuthGeneratedRequestContinuityError()
+        }
+
+        guard !Task.isCancelled,
+              isActiveExactAuthRequestScope(scope),
+              prepared.url?.absoluteString == boundURL.absoluteString,
+              prepared.httpMethod == request.httpMethod,
+              prepared.httpBody == request.httpBody,
+              prepared.httpBodyStream == nil,
+              let authorization = prepared.value(forHTTPHeaderField: "Authorization"),
+              !authorization.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              prepared.value(forHTTPHeaderField: "Cookie") == nil,
+              prepared.value(forHTTPHeaderField: "Proxy-Authorization") == nil,
+              await exactAuthSnapshot(
+                  for: captured.provider,
+                  at: captured.revision,
+                  matching: scope.expected
+              ),
+              scope.state.claimLaunch()
+        else {
+            scope.state.failContinuity()
+            throw ExactAuthGeneratedRequestContinuityError()
+        }
+
+        let (rawData, response) = try await exactAuthSession.data(for: prepared)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse(description: "Received non-HTTP response")
+        }
+        let contentEncoding = httpResponse.value(forHTTPHeaderField: "Content-Encoding")
+        let data = ContentDecoding.decompressIfNeeded(rawData, contentEncoding: contentEncoding)
+
+        guard await exactAuthSnapshot(
+            for: captured.provider,
+            at: captured.revision,
+            matching: scope.expected
+        ),
+            isActiveExactAuthRequestScope(scope),
+            httpResponse.url?.absoluteString == boundURL.absoluteString,
+            scope.state.completeResponse()
+        else {
+            scope.state.failContinuity()
+            throw ExactAuthGeneratedRequestContinuityError()
+        }
+        return (data, httpResponse)
+    }
+
+    private func isActiveExactAuthRequestScope(_ scope: ExactAuthGeneratedRequestScope) -> Bool {
+        guard scope.networkServiceID == exactAuthRequestScopeServiceID,
+              activeExactAuthRequestScope?.id == scope.id,
+              activeExactAuthRequestScope?.expected == scope.expected,
+              activeExactAuthRequestScope?.origin == scope.origin,
+              activeExactAuthRequestScope?.destinationGeneration == scope.destinationGeneration,
+              exactAuthDestinationGeneration == scope.destinationGeneration,
+              ExactAuthRequestOrigin(baseURL) == scope.origin
+        else {
+            return false
+        }
+        return true
+    }
+
+    private nonisolated static func isCredentialHeader(_ name: String) -> Bool {
+        switch name.lowercased() {
+        case "authorization", "dpop", "cookie", "proxy-authorization":
+            return true
+        default:
+            return false
+        }
     }
 
     /// Performs a GET request to the specified endpoint.

--- a/Tests/PetrelTests/AuthContinuityNetworkRequestTests.swift
+++ b/Tests/PetrelTests/AuthContinuityNetworkRequestTests.swift
@@ -1,0 +1,825 @@
+import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+@testable import Petrel
+import XCTest
+
+final class AuthContinuityNetworkRequestTests: XCTestCase {
+    private let baseURL = URL(string: "https://example.com")!
+
+    override class func setUp() {
+        super.setUp()
+        NetworkService.setNetworkTestProtocolClasses([ExactAuthURLProtocol.self])
+    }
+
+    override class func tearDown() {
+        NetworkService.setNetworkTestProtocolClasses(nil)
+        super.tearDown()
+    }
+
+    func testGeneratedEndpointUsesOnePreparedRequestWithoutRefresh() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(
+            matching: fixture.snapshot
+        ) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertPerformed(result, responseCode: 200)
+        let requests = await fixture.transport.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.value(forHTTPHeaderField: "Authorization"), "Bearer old-token")
+        let refreshCount = await fixture.provider.refreshCount
+        let prepareCount = await fixture.provider.prepareCount
+        XCTAssertEqual(refreshCount, 0)
+        XCTAssertEqual(prepareCount, 1)
+    }
+
+    func testProviderReplacesAllPreexistingCredentialHeaders() async throws {
+        let fixture = await makeFixture()
+        await fixture.client.networkService.setHeader(name: "Authorization", value: "Bearer attacker")
+        await fixture.client.networkService.setHeader(name: "DPoP", value: "attacker-proof")
+        await fixture.client.networkService.setHeader(name: "Cookie", value: "session=attacker")
+        await fixture.client.networkService.setHeader(name: "Proxy-Authorization", value: "Basic attacker")
+
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertPerformed(result, responseCode: 200)
+        let capturedRequest = await fixture.transport.requests.first
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer old-token")
+        XCTAssertNil(request.value(forHTTPHeaderField: "DPoP"))
+        XCTAssertNil(request.value(forHTTPHeaderField: "Cookie"))
+        XCTAssertNil(request.value(forHTTPHeaderField: "Proxy-Authorization"))
+    }
+
+    func testOrdinaryRequestBehaviorResumesAfterScopeEnds() async throws {
+        let fixture = await makeFixture()
+        let scoped = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+        assertPerformed(scoped, responseCode: 200)
+
+        let ordinary = try await fixture.client.com.atproto.server.describeServer()
+        XCTAssertEqual(ordinary.responseCode, 200)
+        let requestCount = await fixture.transport.requests.count
+        let refreshCount = await fixture.provider.refreshCount
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(refreshCount, 1)
+    }
+
+    func testPrepareGatedDriftSendsNothing() async throws {
+        let prepareGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(prepareGate: prepareGate)
+
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForPrepare()
+        await fixture.provider.mutate(token: "new-token")
+        await prepareGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testProviderReplacementDuringPreparationSendsNothing() async throws {
+        let prepareGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(prepareGate: prepareGate)
+        let replacement = ExactAuthProvider(
+            snapshot: AuthContinuitySnapshot(did: "did:plc:replacement", mode: .gateway, generation: 1),
+            token: "replacement-token",
+            addAuthorization: true,
+            preparedHeaders: [:],
+            preparedURL: nil,
+            prepareGate: nil
+        )
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForPrepare()
+        await fixture.client.networkService.setAuthenticationProvider(replacement)
+        await prepareGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testProviderSuppliedCookieFailsClosedBeforeLaunch() async throws {
+        let fixture = await makeFixture(preparedHeaders: ["Cookie": "session=unexpected"])
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testCrossOriginRawRequestFailsBeforePreparingCredentials() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            let request = URLRequest(url: URL(string: "https://example.org/xrpc/attacker")!)
+            return try await fixture.client.networkService.performRequest(request)
+        }
+
+        assertContinuityChanged(result)
+        let prepareCount = await fixture.provider.prepareCount
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(prepareCount, 0)
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testBaseURLDriftFailsBeforePreparingCredentials() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            await fixture.client.networkService.setBaseURL(URL(string: "https://example.org")!)
+            return try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let prepareCount = await fixture.provider.prepareCount
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(prepareCount, 0)
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testBaseURLDriftDuringPreparationSendsNothing() async throws {
+        let prepareGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(prepareGate: prepareGate)
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForPrepare()
+        try await fixture.client.networkService.setBaseURL(XCTUnwrap(URL(string: "https://example.org")))
+        await prepareGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testBaseURLDriftWhileResponseHeldDiscardsResponse() async throws {
+        let responseGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(responseGate: responseGate)
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.transport.waitForRequestCount(1)
+        try await fixture.client.networkService.setBaseURL(XCTUnwrap(URL(string: "https://example.org")))
+        await responseGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testProviderCannotRewritePreparedRequestOrigin() async throws {
+        let fixture = try await makeFixture(preparedURL: XCTUnwrap(URL(string: "https://example.org/xrpc/attacker")))
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let prepareCount = await fixture.provider.prepareCount
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(prepareCount, 1)
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testProviderCannotRewritePreparedRequestWithinSameOrigin() async throws {
+        let fixture = try await makeFixture(
+            preparedURL: XCTUnwrap(URL(string: "https://example.com/xrpc/com.atproto.server.createAccount?admin=true"))
+        )
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let prepareCount = await fixture.provider.prepareCount
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(prepareCount, 1)
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testResponseHeldDriftSendsOneOldAuthRequestThenDiscardsResponse() async throws {
+        let responseGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(responseGate: responseGate)
+
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.transport.waitForRequestCount(1)
+        await fixture.provider.mutate(token: "new-token")
+        await responseGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requests = await fixture.transport.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Authorization"), "Bearer old-token")
+    }
+
+    func testExactScopeDoesNotReplay401NonceOrServerErrors() async throws {
+        for status in [401, 500] {
+            let fixture = await makeFixture(statusCode: status, headers: ["DPoP-Nonce": "do-not-store"])
+            let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+
+            assertPerformed(result, responseCode: status)
+            let requestCount = await fixture.transport.requests.count
+            let refreshCount = await fixture.provider.refreshCount
+            let unauthorizedCount = await fixture.provider.unauthorizedCount
+            let nonceUpdateCount = await fixture.provider.nonceUpdateCount
+            XCTAssertEqual(requestCount, 1)
+            XCTAssertEqual(refreshCount, 0)
+            XCTAssertEqual(unauthorizedCount, 0)
+            XCTAssertEqual(nonceUpdateCount, 0)
+        }
+    }
+
+    func testExactScopeDoesNotFollowRedirectOrCarryAuthorization() async throws {
+        let fixture = await makeFixture(
+            statusCode: 302,
+            headers: ["Location": "https://redirect-target.example/xrpc/com.atproto.server.describeServer"]
+        )
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertPerformed(result, responseCode: 302)
+        let requests = await fixture.transport.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].url?.host, baseURL.host)
+    }
+
+    func testNoRedirectDelegateRejectsFoundationRedirectCallback() async throws {
+        let delegate = HardenedURLSessionDelegate(allowsRedirects: false)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        let originalURL = try XCTUnwrap(URL(string: "https://example.com/xrpc/original"))
+        let redirectedURL = try XCTUnwrap(URL(string: "https://example.org/xrpc/redirected"))
+        let task = session.dataTask(with: originalURL)
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: originalURL,
+            statusCode: 302,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Location": redirectedURL.absoluteString]
+        ))
+        var redirectedRequest = URLRequest(url: redirectedURL)
+        redirectedRequest.setValue("Bearer must-not-follow", forHTTPHeaderField: "Authorization")
+
+        let acceptedRequest = await withCheckedContinuation { continuation in
+            delegate.urlSession(
+                session,
+                task: task,
+                willPerformHTTPRedirection: response,
+                newRequest: redirectedRequest,
+                completionHandler: { continuation.resume(returning: $0) }
+            )
+        }
+        XCTAssertNil(acceptedRequest)
+    }
+
+    func testMissingAuthorizationFailsClosedBeforeLaunch() async throws {
+        let fixture = await makeFixture(addAuthorization: false)
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testForeignNetworkServiceFailsClosedBeforeLaunch() async throws {
+        let fixture = await makeFixture()
+        let foreign = await makeFixture(host: "example.org")
+        let foreignNetworkService = await foreign.client.networkService
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            let endpoint = ATProtoClient.Com.Atproto.Server(networkService: foreignNetworkService)
+            return try await endpoint.describeServer()
+        }
+
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        let foreignRequestCount = await foreign.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+        XCTAssertEqual(foreignRequestCount, 0)
+    }
+
+    func testMismatchedNestedScopeFailsWholeOperationClosed() async throws {
+        let fixture = await makeFixture()
+        let mismatched = AuthContinuitySnapshot(
+            did: fixture.snapshot.did,
+            mode: fixture.snapshot.mode,
+            generation: fixture.snapshot.generation &+ 1
+        )
+
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: mismatched) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testMatchingNestedScopePerformsExactlyOneRequest() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+
+        guard case let .performed(inner) = result else {
+            return XCTFail("Expected outer scope to perform")
+        }
+        assertPerformed(inner, responseCode: 200)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testZeroRequestClosureFailsClosedAndReleasesService() async throws {
+        let fixture = await makeFixture()
+        let empty = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            42
+        }
+        assertContinuityChanged(empty)
+
+        let subsequent = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+        assertPerformed(subsequent, responseCode: 200)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testEscapedInheritedTaskHeldBeforeLaunchCannotSendAfterScopeCleanup() async throws {
+        let prepareGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(prepareGate: prepareGate)
+        let escaped = EscapedRequestTaskStore()
+
+        let outer = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            let task = Task {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+            await escaped.store(task)
+            await fixture.provider.waitForPrepare()
+            return 7
+        }
+        assertContinuityChanged(outer)
+        await prepareGate.open()
+        _ = try? await escaped.value()
+
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+
+        let subsequent = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+        assertPerformed(subsequent, responseCode: 200)
+        let finalCount = await fixture.transport.requests.count
+        XCTAssertEqual(finalCount, 1)
+    }
+
+    func testEscapedInheritedTaskHeldAfterLaunchCannotCompleteScope() async throws {
+        let responseGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(responseGate: responseGate)
+        let escaped = EscapedRequestTaskStore()
+
+        let outer = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            let task = Task {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+            await escaped.store(task)
+            await fixture.transport.waitForRequestCount(1)
+            return 7
+        }
+        assertContinuityChanged(outer)
+        await responseGate.open()
+        _ = try? await escaped.value()
+
+        let firstCount = await fixture.transport.requests.count
+        XCTAssertEqual(firstCount, 1)
+
+        let subsequent = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await fixture.client.com.atproto.server.describeServer()
+        }
+        assertPerformed(subsequent, responseCode: 200)
+        let finalCount = await fixture.transport.requests.count
+        XCTAssertEqual(finalCount, 2)
+    }
+
+    func testStaleInheritedNestedScopeFailsAfterOwnerScopeEnds() async throws {
+        let fixture = await makeFixture()
+        let childGate = AsyncGate(initiallyOpen: false)
+        let escaped = EscapedNestedScopeTaskStore()
+
+        let outer = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            let task = Task {
+                await childGate.wait()
+                return try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                    42
+                }
+            }
+            await escaped.store(task)
+            return try await fixture.client.com.atproto.server.describeServer()
+        }
+        assertPerformed(outer, responseCode: 200)
+        await childGate.open()
+
+        let stale = try await escaped.value()
+        try assertContinuityChanged(XCTUnwrap(stale))
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testInheritedTaskRemainsScoped() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await Task {
+                try await fixture.client.com.atproto.server.describeServer()
+            }.value
+        }
+
+        assertPerformed(result, responseCode: 200)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testDetachedTaskCannotBypassActiveScope() async throws {
+        let fixture = await makeFixture()
+        let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+            try await Task.detached {
+                try await fixture.client.com.atproto.server.describeServer()
+            }.value
+        }
+
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testCancellationBeforeLaunchSendsNothing() async {
+        let prepareGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(prepareGate: prepareGate)
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForPrepare()
+        task.cancel()
+        await prepareGate.open()
+
+        _ = try? await task.value
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testCancellationAfterLaunchCannotUndoServerEffect() async {
+        let responseGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture(responseGate: responseGate)
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.transport.waitForRequestCount(1)
+        task.cancel()
+        await responseGate.open()
+
+        _ = try? await task.value
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    private func makeFixture(
+        host: String = "example.com",
+        statusCode: Int = 200,
+        headers: [String: String] = [:],
+        addAuthorization: Bool = true,
+        preparedHeaders: [String: String] = [:],
+        preparedURL: URL? = nil,
+        prepareGate: AsyncGate? = nil,
+        responseGate: AsyncGate? = nil
+    ) async -> Fixture {
+        let url = URL(string: "https://\(host)")!
+        let provider = ExactAuthProvider(
+            snapshot: AuthContinuitySnapshot(did: "did:plc:exact", mode: .gateway, generation: 7),
+            token: "old-token",
+            addAuthorization: addAuthorization,
+            preparedHeaders: preparedHeaders,
+            preparedURL: preparedURL,
+            prepareGate: prepareGate
+        )
+        let client = await ATProtoClient(baseURL: url)
+        await client.networkService.setAuthenticationProvider(provider)
+        let snapshot = await client.authContinuitySnapshot()
+        let transport = ExactAuthTransport(statusCode: statusCode, headers: headers, responseGate: responseGate)
+        ExactAuthURLProtocol.install(transport, forHost: host)
+        return Fixture(client: client, provider: provider, transport: transport, snapshot: snapshot)
+    }
+
+    private func assertPerformed(
+        _ result: AuthContinuityTransactionResult<(responseCode: Int, data: ComAtprotoServerDescribeServer.Output?)>,
+        responseCode: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case let .performed(value) = result else {
+            return XCTFail("Expected performed result", file: file, line: line)
+        }
+        XCTAssertEqual(value.responseCode, responseCode, file: file, line: line)
+    }
+
+    private func assertContinuityChanged<Value>(
+        _ result: AuthContinuityTransactionResult<Value>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .continuityChanged = result else {
+            return XCTFail("Expected continuityChanged", file: file, line: line)
+        }
+    }
+}
+
+private struct Fixture {
+    let client: ATProtoClient
+    let provider: ExactAuthProvider
+    let transport: ExactAuthTransport
+    let snapshot: AuthContinuitySnapshot
+}
+
+private actor EscapedRequestTaskStore {
+    typealias Response = (responseCode: Int, data: ComAtprotoServerDescribeServer.Output?)
+    private var task: Task<Response, Error>?
+
+    func store(_ task: Task<Response, Error>) {
+        self.task = task
+    }
+
+    func value() async throws -> Response? {
+        try await task?.value
+    }
+}
+
+private actor EscapedNestedScopeTaskStore {
+    private var task: Task<AuthContinuityTransactionResult<Int>, Error>?
+
+    func store(_ task: Task<AuthContinuityTransactionResult<Int>, Error>) {
+        self.task = task
+    }
+
+    func value() async throws -> AuthContinuityTransactionResult<Int>? {
+        try await task?.value
+    }
+}
+
+private actor ExactAuthProvider: AuthContinuityProviding {
+    private var snapshot: AuthContinuitySnapshot
+    private var token: String
+    private let addAuthorization: Bool
+    private let preparedHeaders: [String: String]
+    private let preparedURL: URL?
+    private let prepareGate: AsyncGate?
+    private var observer: (@Sendable () async -> Void)?
+    private let prepareEvent = AsyncEvent()
+    private(set) var refreshCount = 0
+    private(set) var prepareCount = 0
+    private(set) var unauthorizedCount = 0
+    private(set) var nonceUpdateCount = 0
+
+    init(
+        snapshot: AuthContinuitySnapshot,
+        token: String,
+        addAuthorization: Bool,
+        preparedHeaders: [String: String],
+        preparedURL: URL?,
+        prepareGate: AsyncGate?
+    ) {
+        self.snapshot = snapshot
+        self.token = token
+        self.addAuthorization = addAuthorization
+        self.preparedHeaders = preparedHeaders
+        self.preparedURL = preparedURL
+        self.prepareGate = prepareGate
+    }
+
+    func installAuthContinuityObserver(_ observer: @escaping @Sendable () async -> Void) async {
+        self.observer = observer
+    }
+
+    func authContinuitySnapshot() async -> AuthContinuitySnapshot {
+        snapshot
+    }
+
+    func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
+        .stable(snapshot)
+    }
+
+    func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {
+        try await prepareAuthenticatedRequestWithContext(request).0
+    }
+
+    func prepareAuthenticatedRequestWithContext(_ request: URLRequest) async throws -> (URLRequest, AuthContext) {
+        prepareCount += 1
+        let capturedToken = token
+        await prepareEvent.signal()
+        if let prepareGate { await prepareGate.wait() }
+        var prepared = request
+        if addAuthorization {
+            prepared.setValue("Bearer \(capturedToken)", forHTTPHeaderField: "Authorization")
+        }
+        for (name, value) in preparedHeaders {
+            prepared.setValue(value, forHTTPHeaderField: name)
+        }
+        if let preparedURL {
+            prepared.url = preparedURL
+        }
+        return (prepared, AuthContext(did: snapshot.did, jkt: nil))
+    }
+
+    func refreshTokenIfNeeded() async throws -> TokenRefreshResult {
+        refreshCount += 1
+        return .stillValid
+    }
+
+    func handleUnauthorizedResponse(
+        _ response: HTTPURLResponse,
+        data: Data,
+        for _: URLRequest
+    ) async throws -> (Data, HTTPURLResponse) {
+        unauthorizedCount += 1
+        return (data, response)
+    }
+
+    func updateDPoPNonce(for _: URL, from _: [String: String], did _: String?, jkt _: String?) async {
+        nonceUpdateCount += 1
+    }
+
+    func waitForPrepare() async {
+        await prepareEvent.wait()
+    }
+
+    func mutate(token: String) async {
+        await observer?()
+        self.token = token
+        snapshot = AuthContinuitySnapshot(
+            did: snapshot.did,
+            mode: snapshot.mode,
+            generation: snapshot.generation &+ 1
+        )
+    }
+}
+
+private actor ExactAuthTransport {
+    private let statusCode: Int
+    private let headers: [String: String]
+    private let responseGate: AsyncGate?
+    private let requestEvent = AsyncEvent()
+    private(set) var requests: [URLRequest] = []
+
+    init(statusCode: Int, headers: [String: String], responseGate: AsyncGate?) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.responseGate = responseGate
+    }
+
+    func handle(_ request: URLRequest, protocolInstance: ExactAuthURLProtocol) async {
+        requests.append(request)
+        await requestEvent.signal()
+        if let responseGate { await responseGate.wait() }
+        guard !Task.isCancelled, let url = request.url else { return }
+        var responseHeaders = headers
+        responseHeaders["Content-Type"] = responseHeaders["Content-Type"] ?? "application/json"
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: responseHeaders
+        )!
+        let body = Data(#"{"availableUserDomains":["example"],"did":"did:web:example"}"#.utf8)
+        protocolInstance.client?.urlProtocol(protocolInstance, didReceive: response, cacheStoragePolicy: .notAllowed)
+        protocolInstance.client?.urlProtocol(protocolInstance, didLoad: body)
+        protocolInstance.client?.urlProtocolDidFinishLoading(protocolInstance)
+    }
+
+    func waitForRequestCount(_ count: Int) async {
+        while requests.count < count {
+            await requestEvent.wait()
+        }
+    }
+}
+
+private final class ExactAuthURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var transports: [String: ExactAuthTransport] = [:]
+    private var loadingTask: Task<Void, Never>?
+
+    static func install(_ transport: ExactAuthTransport, forHost host: String) {
+        lock.withLock { transports[host] = transport }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        lock.withLock { transports[request.url?.host ?? ""] != nil }
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let host = request.url?.host,
+              let transport = Self.lock.withLock({ Self.transports[host] })
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+        let box = ExactAuthURLProtocolBox(protocolInstance: self, request: request)
+        loadingTask = Task {
+            await transport.handle(box.request, protocolInstance: box.protocolInstance)
+        }
+    }
+
+    override func stopLoading() {
+        loadingTask?.cancel()
+        loadingTask = nil
+        client?.urlProtocol(self, didFailWithError: URLError(.cancelled))
+    }
+}
+
+private final class ExactAuthURLProtocolBox: @unchecked Sendable {
+    let protocolInstance: ExactAuthURLProtocol
+    let request: URLRequest
+
+    init(protocolInstance: ExactAuthURLProtocol, request: URLRequest) {
+        self.protocolInstance = protocolInstance
+        self.request = request
+    }
+}
+
+private actor AsyncEvent {
+    private var signaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        signaled = true
+        let current = waiters
+        waiters.removeAll()
+        current.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if signaled {
+            signaled = false
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen: Bool
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(initiallyOpen: Bool) {
+        isOpen = initiallyOpen
+    }
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let current = waiters
+        waiters.removeAll()
+        current.forEach { $0.resume() }
+    }
+}

--- a/Tests/PetrelTests/AuthContinuityNetworkRequestTests.swift
+++ b/Tests/PetrelTests/AuthContinuityNetworkRequestTests.swift
@@ -18,6 +18,15 @@ final class AuthContinuityNetworkRequestTests: XCTestCase {
         super.tearDown()
     }
 
+    func testExactResponseContentEncodingLookupIsCaseInsensitive() {
+        let headerFields: [AnyHashable: Any] = ["cOnTeNt-EnCoDiNg": "br"]
+
+        XCTAssertEqual(
+            ContentDecoding.headerValue(named: "Content-Encoding", in: headerFields),
+            "br"
+        )
+    }
+
     func testGeneratedEndpointUsesOnePreparedRequestWithoutRefresh() async throws {
         let fixture = await makeFixture()
         let result = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(
@@ -363,6 +372,60 @@ final class AuthContinuityNetworkRequestTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
+    func testConcurrentScopeAcquisitionDoesNotOverwriteInstalledOwner() async throws {
+        let heldSnapshotGate = AsyncGate(initiallyOpen: false)
+        let secondOperationGate = AsyncGate(initiallyOpen: false)
+        let secondOperationStarted = AsyncEvent()
+        let fixture = await makeFixture()
+        await fixture.provider.holdNextProviderSnapshot(on: heldSnapshotGate)
+
+        let first = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForHeldProviderSnapshot()
+
+        let second = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                await secondOperationStarted.signal()
+                await secondOperationGate.wait()
+                return try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await secondOperationStarted.wait()
+
+        await heldSnapshotGate.open()
+        let firstResult = try await first.value
+        assertContinuityChanged(firstResult)
+
+        await secondOperationGate.open()
+        let secondResult = try await second.value
+        assertPerformed(secondResult, responseCode: 200)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testDestinationGenerationDriftDuringScopeAcquisitionFailsClosed() async throws {
+        let heldSnapshotGate = AsyncGate(initiallyOpen: false)
+        let fixture = await makeFixture()
+        await fixture.provider.holdNextProviderSnapshot(on: heldSnapshotGate)
+
+        let task = Task {
+            try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
+                try await fixture.client.com.atproto.server.describeServer()
+            }
+        }
+        await fixture.provider.waitForHeldProviderSnapshot()
+        await fixture.client.networkService.setBaseURL(baseURL)
+        await heldSnapshotGate.open()
+
+        let result = try await task.value
+        assertContinuityChanged(result)
+        let requestCount = await fixture.transport.requests.count
+        XCTAssertEqual(requestCount, 0)
+    }
+
     func testZeroRequestClosureFailsClosedAndReleasesService() async throws {
         let fixture = await makeFixture()
         let empty = try await fixture.client.performGeneratedRequestWithExactAuthContinuity(matching: fixture.snapshot) {
@@ -607,6 +670,9 @@ private actor ExactAuthProvider: AuthContinuityProviding {
     private let preparedHeaders: [String: String]
     private let preparedURL: URL?
     private let prepareGate: AsyncGate?
+    private var providerSnapshotGate: AsyncGate?
+    private var shouldHoldNextProviderSnapshot = false
+    private let heldProviderSnapshotEvent = AsyncEvent()
     private var observer: (@Sendable () async -> Void)?
     private let prepareEvent = AsyncEvent()
     private(set) var refreshCount = 0
@@ -639,7 +705,21 @@ private actor ExactAuthProvider: AuthContinuityProviding {
     }
 
     func authContinuityProviderSnapshot() async -> AuthContinuityProviderSnapshot {
-        .stable(snapshot)
+        if shouldHoldNextProviderSnapshot, let providerSnapshotGate {
+            shouldHoldNextProviderSnapshot = false
+            await heldProviderSnapshotEvent.signal()
+            await providerSnapshotGate.wait()
+        }
+        return .stable(snapshot)
+    }
+
+    func holdNextProviderSnapshot(on gate: AsyncGate) {
+        providerSnapshotGate = gate
+        shouldHoldNextProviderSnapshot = true
+    }
+
+    func waitForHeldProviderSnapshot() async {
+        await heldProviderSnapshotEvent.wait()
     }
 
     func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {


### PR DESCRIPTION
## Summary
- add a public exact-auth continuity wrapper for one directly awaited generated request
- bind provider identity, auth snapshot, exact HTTPS destination, request URL/method/body, and postvalidated response to one no-retry/no-redirect launch
- fail closed on stale/inherited scope escape, provider or destination drift, credential-header injection, redirects, and extra/zero requests
- add 28 adversarial generated-request regression tests

## Verification
- `swift test --filter AuthContinuityNetworkRequestTests` (28 passed)
- `swift test --filter AuthContinuityTests` (22 passed)
- `swift test` (67 XCTest + 134 Swift Testing passed)
- `swift build`
- `swift build -c release`
- independent adversarial review: APPROVE

## Compatibility
The wrapper is intentionally narrow: it accepts exactly one directly awaited generated request to the captured HTTPS origin. During an active scope, unrelated requests on that same `NetworkService` fail closed. Streaming request bodies are rejected.