### PR TITLE
fix(types): tolerate $type framing in lossless-decode round-trip guard

### DIFF
--- a/Sources/Petrel/Generated/Core/Types/ATProtocolValueContainer.swift
+++ b/Sources/Petrel/Generated/Core/Types/ATProtocolValueContainer.swift
@@ -3431,13 +3431,57 @@ public indirect enum ATProtocolValueContainer: ATProtocolCodable, ATProtocolValu
         }
 
         do {
-            guard try typedValue.encodedDAGCBOR() == rawObject.encodedDAGCBOR() else {
+            guard try dagCBOREqualIgnoringTypeFraming(typedValue, rawObject) else {
                 return rawFallback
             }
         } catch {
             return rawFallback
         }
         return typedValue
+    }
+
+    /// Lossless-decode check that tolerates `$type` framing differences.
+    ///
+    /// Generated `encode(to:)` implementations frame every nested object
+    /// definition with its `$type` discriminator, while records written by
+    /// real AT Protocol clients omit `$type` on non-union nested objects
+    /// (facet `index`, embed `images[]`, `aspectRatio`, `reply` refs,
+    /// self-label values, …). A byte-exact DAG-CBOR comparison therefore
+    /// spuriously rejects faithful decodes of ordinary wire records. Comparing
+    /// after stripping `$type` entries from both sides keeps the guard's
+    /// purpose intact: dropped future fields and malformed optionals degraded
+    /// to nil still differ after normalization and fall back to the raw
+    /// representation.
+    private static func dagCBOREqualIgnoringTypeFraming(
+        _ typed: ATProtocolValueContainer,
+        _ raw: ATProtocolValueContainer
+    ) throws -> Bool {
+        try normalizedDAGCBORBytes(typed) == normalizedDAGCBORBytes(raw)
+    }
+
+    private static func normalizedDAGCBORBytes(_ value: ATProtocolValueContainer) throws -> Data {
+        try DAGCBOR.encodeValue(strippingTypeFraming(value.toCBORValue()))
+    }
+
+    private static func strippingTypeFraming(_ value: Any) -> Any {
+        switch value {
+        case let map as OrderedCBORMap:
+            return OrderedCBORMap(entries: map.entries.compactMap { entry in
+                entry.key == "$type"
+                    ? nil
+                    : (key: entry.key, value: strippingTypeFraming(entry.value))
+            })
+        case let dict as [String: Any]:
+            return dict.reduce(into: [String: Any]()) { result, element in
+                if element.key != "$type" {
+                    result[element.key] = strippingTypeFraming(element.value)
+                }
+            }
+        case let array as [Any]:
+            return array.map(strippingTypeFraming)
+        default:
+            return value
+        }
     }
 
     private static func decodeSpecialObject(

--- a/Tests/PetrelTests/ATProtocolValueContainerTypeFramingTests.swift
+++ b/Tests/PetrelTests/ATProtocolValueContainerTypeFramingTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+
+@testable import Petrel
+
+/// Regression tests for the lossless-decode round-trip guard.
+///
+/// Generated `encode(to:)` implementations frame every nested object definition
+/// with its `$type` discriminator, while records written by real AT Protocol
+/// clients omit `$type` on non-union nested objects (facet `index`, embed
+/// `images[]`, `aspectRatio`, `reply` refs, self-label values, …). The guard
+/// must not treat that framing difference as data loss, or every real-world
+/// post containing those fields demotes to `.unknownType` and renderers
+/// tombstone it ("Post format error" in Catbird).
+struct ATProtocolValueContainerTypeFramingTests {
+  /// Verbatim wire record (facets post) as returned by the AppView for
+  /// at://…/app.bsky.feed.post/3mqyilqx6qc2d — nested objects carry no `$type`.
+  private static let facetedRecordJSON = """
+    {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "2026-07-19T09:31:59.000Z",
+      "facets": [
+        {
+          "features": [
+            {"$type": "app.bsky.richtext.facet#mention", "did": "did:plc:yirep3fqwvhazp5kcimfo2ne"}
+          ],
+          "index": {"byteEnd": 48, "byteStart": 19}
+        },
+        {
+          "features": [
+            {"$type": "app.bsky.richtext.facet#link", "uri": "https://catbird.blue"}
+          ],
+          "index": {"byteEnd": 75, "byteStart": 55}
+        },
+        {
+          "features": [
+            {"$type": "app.bsky.richtext.facet#tag", "tag": "CatbirdPreviews"}
+          ],
+          "index": {"byteEnd": 96, "byteStart": 80}
+        }
+      ],
+      "text": "Testing rich text: @catbird-appstore.bsky.social check https://catbird.blue and #CatbirdPreviews"
+    }
+    """
+
+  /// Verbatim wire record (single image post) — blob ref, alt, aspectRatio, no nested `$type`
+  /// beyond the embed union member and the blob itself.
+  private static let imageRecordJSON = """
+    {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "2026-07-19T09:32:07.000Z",
+      "embed": {
+        "$type": "app.bsky.embed.images",
+        "images": [
+          {
+            "alt": "A solid green preview image",
+            "aspectRatio": {"height": 480, "width": 640},
+            "image": {
+              "$type": "blob",
+              "ref": {"$link": "bafkreibubdyzcgxfmpq6grnnwds62djzzujazttf6mbiv5bhcjnzejvw24"},
+              "mimeType": "image/png",
+              "size": 2196
+            }
+          }
+        ]
+      },
+      "text": "One image, landscape, with alt text."
+    }
+    """
+
+  /// Verbatim wire record (reply) — strongRefs with no `$type`.
+  private static let replyRecordJSON = """
+    {
+      "$type": "app.bsky.feed.post",
+      "createdAt": "2026-07-19T09:32:22.000Z",
+      "reply": {
+        "parent": {
+          "cid": "bafyreiblkecirw3zwuqmm7hru77pgxzn2wexvi2kkqbpicrqrqhri7ne2u",
+          "uri": "at://did:plc:oq3qa6f332ergklpj2dvd3up/app.bsky.feed.post/3mqyilyckxx2h"
+        },
+        "root": {
+          "cid": "bafyreiblkecirw3zwuqmm7hru77pgxzn2wexvi2kkqbpicrqrqhri7ne2u",
+          "uri": "at://did:plc:oq3qa6f332ergklpj2dvd3up/app.bsky.feed.post/3mqyilyckxx2h"
+        }
+      },
+      "text": "Obviously the catbird. Self-reply, level one."
+    }
+    """
+
+  @Test(
+    "Wire records without nested $type framing decode as known types",
+    arguments: [facetedRecordJSON, imageRecordJSON, replyRecordJSON]
+  )
+  func wireRecordDecodesAsKnownType(_ json: String) throws {
+    let container = try JSONDecoder().decode(
+      ATProtocolValueContainer.self, from: Data(json.utf8))
+    guard case .knownType(let value) = container else {
+      Issue.record("Expected .knownType(AppBskyFeedPost), got \(container)")
+      return
+    }
+    #expect(value is AppBskyFeedPost)
+  }
+
+  @Test("Faceted wire record retains its facets through typed dispatch")
+  func facetsSurviveTypedDispatch() throws {
+    let container = try JSONDecoder().decode(
+      ATProtocolValueContainer.self, from: Data(Self.facetedRecordJSON.utf8))
+    guard case .knownType(let value) = container, let post = value as? AppBskyFeedPost else {
+      Issue.record("Expected .knownType(AppBskyFeedPost), got \(container)")
+      return
+    }
+    #expect(post.facets?.count == 3)
+  }
+
+  @Test("Future fields still demote typed dispatch to the raw fallback")
+  func futureFieldsStillFallBack() throws {
+    let json = """
+      {
+        "$type": "app.bsky.feed.post",
+        "createdAt": "2026-07-19T09:31:59.000Z",
+        "text": "future",
+        "future": {"enabled": true}
+      }
+      """
+    let container = try JSONDecoder().decode(
+      ATProtocolValueContainer.self, from: Data(json.utf8))
+    guard case .unknownType(let type, _) = container else {
+      Issue.record("Expected .unknownType raw fallback for future fields, got \(container)")
+      return
+    }
+    #expect(type == "app.bsky.feed.post")
+  }
+}

--- a/generator/templates/ATProtocolValueContainer.jinja
+++ b/generator/templates/ATProtocolValueContainer.jinja
@@ -180,13 +180,57 @@ public indirect enum ATProtocolValueContainer: ATProtocolCodable, ATProtocolValu
         }
 
         do {
-            guard try typedValue.encodedDAGCBOR() == rawObject.encodedDAGCBOR() else {
+            guard try dagCBOREqualIgnoringTypeFraming(typedValue, rawObject) else {
                 return rawFallback
             }
         } catch {
             return rawFallback
         }
         return typedValue
+    }
+
+    /// Lossless-decode check that tolerates `$type` framing differences.
+    ///
+    /// Generated `encode(to:)` implementations frame every nested object
+    /// definition with its `$type` discriminator, while records written by
+    /// real AT Protocol clients omit `$type` on non-union nested objects
+    /// (facet `index`, embed `images[]`, `aspectRatio`, `reply` refs,
+    /// self-label values, …). A byte-exact DAG-CBOR comparison therefore
+    /// spuriously rejects faithful decodes of ordinary wire records. Comparing
+    /// after stripping `$type` entries from both sides keeps the guard's
+    /// purpose intact: dropped future fields and malformed optionals degraded
+    /// to nil still differ after normalization and fall back to the raw
+    /// representation.
+    private static func dagCBOREqualIgnoringTypeFraming(
+        _ typed: ATProtocolValueContainer,
+        _ raw: ATProtocolValueContainer
+    ) throws -> Bool {
+        try normalizedDAGCBORBytes(typed) == normalizedDAGCBORBytes(raw)
+    }
+
+    private static func normalizedDAGCBORBytes(_ value: ATProtocolValueContainer) throws -> Data {
+        try DAGCBOR.encodeValue(strippingTypeFraming(value.toCBORValue()))
+    }
+
+    private static func strippingTypeFraming(_ value: Any) -> Any {
+        switch value {
+        case let map as OrderedCBORMap:
+            return OrderedCBORMap(entries: map.entries.compactMap { entry in
+                entry.key == "$type"
+                    ? nil
+                    : (key: entry.key, value: strippingTypeFraming(entry.value))
+            })
+        case let dict as [String: Any]:
+            return dict.reduce(into: [String: Any]()) { result, element in
+                if element.key != "$type" {
+                    result[element.key] = strippingTypeFraming(element.value)
+                }
+            }
+        case let array as [Any]:
+            return array.map(strippingTypeFraming)
+        default:
+            return value
+        }
     }
 
     private static func decodeSpecialObject(


### PR DESCRIPTION
## Problem

The lossless-decode round-trip guard introduced in 85a5ead0 ("decode value containers losslessly", shipped in 1.0.1) compares typed re-encode vs raw wire bytes **exactly**. Generated `encode(to:)` frames every nested object def with `$type`, but real AT Protocol clients omit `$type` on non-union nested objects (facet `index`, embed `images[]`, `aspectRatio`, `reply` refs, self-label values…).

Result: **every real-world post containing facets, media embeds, replies, or self-labels demotes to `.unknownType`** — Catbird main renders them all as "Post format error" tombstones (verified on-simulator with verbatim AppView responses).

## Fix

Compare `$type`-stripped canonical DAG-CBOR on both sides. Framing differences pass; the guard's actual contract is preserved — dropped future fields and malformed optionals degraded to nil still differ after normalization and fall back to raw (existing strict tests all green).

Template change + deterministic regen (petrel-core manifest + swiftformat — only `ATProtocolValueContainer.swift` changed). New regression suite uses verbatim wire records.

## Tests
- 194/194 PetrelTests incl. new `ATProtocolValueContainerTypeFramingTests` (3 verbatim wire records → `.knownType`; future-field fallback still enforced)

## Release note
Please cut **1.0.2** from this (Catbird pins `upToNextMajor(1.0.1)`); tag creation was left to the repo owner deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)