### PR TITLE
fix(cab): update JKT-scoped DPoP nonce stores on refresh

### DIFF
--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -299,6 +299,29 @@ actor OAuthCore {
             nonces[domain] = nonce
             try await storage.saveDPoPNonces(nonces, for: did)
         } catch {}
+
+        // Also update the JKT-scoped nonce stores. `createDPoPProof` resolves the nonce
+        // for a domain from the in-memory `noncesByThumbprint` and the persisted
+        // JKT-scoped store *before* falling back to the DID-scoped store updated above.
+        // Updating only the DID-scoped store therefore leaves a stale JKT nonce that
+        // shadows the fresh one — the CAB refresh path (`CABOAuthStrategy.performTokenRefresh`)
+        // then keeps replaying the stale nonce and every `use_dpop_nonce` retry fails,
+        // so the session can never refresh. Mirror `AuthenticationService.updateAndVerifyNonce`
+        // and write every store `createDPoPProof` reads.
+        if let key = try? await getOrCreateDPoPKey(for: did),
+           let jwk = try? createJWK(from: key),
+           let thumbprint = try? calculateJWKThumbprint(jwk: jwk)
+        {
+            var memDomainMap = noncesByThumbprint[thumbprint] ?? [:]
+            memDomainMap[domain] = nonce
+            noncesByThumbprint[thumbprint] = memDomainMap
+
+            var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: did)) ?? [:]
+            var jktDomainMap = jktNonces[thumbprint] ?? [:]
+            jktDomainMap[domain] = nonce
+            jktNonces[thumbprint] = jktDomainMap
+            try? await storage.saveDPoPNoncesByJKT(jktNonces, for: did)
+        }
     }
 
     // MARK: - Metadata Fetching


### PR DESCRIPTION
CABOAuthStrategy.performTokenRefresh applies the server's fresh DPoP nonce via OAuthCore.updateDPoPNonceInternal, which wrote only the DID-scoped nonce store. But createDPoPProof resolves the nonce from the in-memory noncesByThumbprint and the persisted JKT-scoped store *before* the DID-scoped store, so a stale JKT nonce (from login) permanently shadows the fresh one. Every use_dpop_nonce retry then replays the stale nonce and the session can never refresh (works in gateway mode, which uses updateAndVerifyNonce that writes all stores).

Update the in-memory and persisted JKT stores too, mirroring updateAndVerifyNonce.