### PR TITLE
fix(dpop): unify nonce store writes and clears

### DIFF
--- a/Sources/Petrel/Account/AccountManager.swift
+++ b/Sources/Petrel/Account/AccountManager.swift
@@ -293,6 +293,21 @@ actor AccountManager: AccountManaging {
         // Delete related data
         try await storage.deleteSession(for: did)
         try await storage.deleteDPoPKey(for: did)
+
+        // Both nonce stores, mirroring `clearInconsistentAuthenticationState`: leaving
+        // them behind lets nonces bound to the DPoP key just deleted survive into a later
+        // re-login with the same DID. Failure here must not fail the removal.
+        do {
+            try await storage.saveDPoPNonces([:], for: did)
+            try await storage.saveDPoPNoncesByJKT([:], for: did)
+            LogManager.logDebug(
+                "AccountManager - Cleared DPoP nonces for removed DID: \(LogManager.logDID(did))"
+            )
+        } catch {
+            LogManager.logWarning(
+                "AccountManager - Failed to clear DPoP nonces for removed DID: \(LogManager.logDID(did)): \(error)"
+            )
+        }
     }
 
     /// Sets the current active account.

--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -222,13 +222,22 @@ actor OAuthCore {
         {
             finalNonce = oauthFlowNonces[domain]
         } else if let targetDID = targetDID, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
-            // Multi-layer nonce retrieval
+            // Re-merge the persisted JKT-scoped nonces into memory, letting persistence win.
+            // Every strategy builds its own OAuthCore (and app extensions share the keychain
+            // access group), so another writer can hold a fresher nonce than this actor's
+            // cache — without this merge the stale in-memory entry shadows it.
+            if let persistedByJKT = try? await storage.getDPoPNoncesByJKT(for: targetDID) {
+                for (persistedThumbprint, domainMap) in persistedByJKT {
+                    var merged = noncesByThumbprint[persistedThumbprint] ?? [:]
+                    merged.merge(domainMap) { _, new in new }
+                    noncesByThumbprint[persistedThumbprint] = merged
+                }
+            }
+
+            // Multi-layer nonce retrieval: JKT-scoped (in-memory, now including everything
+            // persisted above) first, DID-scoped persistence as the fallback.
             if let jktNonce = noncesByThumbprint[keyThumbprint]?[domain] {
                 finalNonce = jktNonce
-            } else if let persistedJktNonces = try? await storage.getDPoPNoncesByJKT(for: targetDID),
-                      let jktPersistentNonce = persistedJktNonces[keyThumbprint]?[domain]
-            {
-                finalNonce = jktPersistentNonce
             } else if let storedNonces = try? await storage.getDPoPNonces(for: targetDID),
                       let didNonce = storedNonces[domain]
             {
@@ -293,34 +302,124 @@ actor OAuthCore {
         return newKey
     }
 
-    func updateDPoPNonceInternal(domain: String, nonce: String, for did: String) async {
+    /// Records `nonce` in every store `createDPoPProof` reads for `did`: the in-memory
+    /// JKT map, the persisted JKT-scoped map, and the persisted DID-scoped map.
+    ///
+    /// Writing only the DID-scoped store is never enough — it sits last in the read
+    /// precedence, so a stale JKT-scoped entry shadows it and the next `use_dpop_nonce`
+    /// retry replays the value the server just rejected.
+    ///
+    /// `thumbprint` is the DPoP key thumbprint when the caller already knows it
+    /// (e.g. from an `AuthContext`); pass `nil` to derive it from the DID's stored key.
+    ///
+    /// - Returns: `false` when the thumbprint could not be resolved, i.e. the
+    ///   JKT-scoped layers still hold whatever stale value shadows this write —
+    ///   callers about to retry a request with the fresh nonce must not bother.
+    @discardableResult
+    private func writeNonceToAllStores(
+        domain: String,
+        nonce: String,
+        did: String,
+        thumbprint: String?
+    ) async -> Bool {
+        var nonces = (try? await storage.getDPoPNonces(for: did)) ?? [:]
+        nonces[domain] = nonce
         do {
-            var nonces = try await storage.getDPoPNonces(for: did) ?? [:]
-            nonces[domain] = nonce
             try await storage.saveDPoPNonces(nonces, for: did)
-        } catch {}
+        } catch {
+            LogManager.logWarning(
+                "Failed to persist DID-scoped DPoP nonce for DID: \(LogManager.logDID(did)), domain: \(domain), error: \(error)",
+                category: .authentication
+            )
+        }
 
-        // Also update the JKT-scoped nonce stores. `createDPoPProof` resolves the nonce
-        // for a domain from the in-memory `noncesByThumbprint` and the persisted
-        // JKT-scoped store *before* falling back to the DID-scoped store updated above.
-        // Updating only the DID-scoped store therefore leaves a stale JKT nonce that
-        // shadows the fresh one — the CAB refresh path (`CABOAuthStrategy.performTokenRefresh`)
-        // then keeps replaying the stale nonce and every `use_dpop_nonce` retry fails,
-        // so the session can never refresh. Mirror `AuthenticationService.updateAndVerifyNonce`
-        // and write every store `createDPoPProof` reads.
-        if let key = try? await getOrCreateDPoPKey(for: did),
-           let jwk = try? createJWK(from: key),
-           let thumbprint = try? calculateJWKThumbprint(jwk: jwk)
-        {
-            var memDomainMap = noncesByThumbprint[thumbprint] ?? [:]
-            memDomainMap[domain] = nonce
-            noncesByThumbprint[thumbprint] = memDomainMap
+        var candidateThumbprint = thumbprint
+        if candidateThumbprint == nil {
+            candidateThumbprint = await dpopKeyThumbprint(for: did)
+        }
+        guard let resolvedThumbprint = candidateThumbprint else {
+            LogManager.logError(
+                "Could not resolve DPoP key thumbprint for DID: \(LogManager.logDID(did)); the fresh nonce for domain \(domain) reached only the DID-scoped store and stays shadowed by the JKT-scoped stores",
+                category: .authentication
+            )
+            return false
+        }
 
-            var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: did)) ?? [:]
-            var jktDomainMap = jktNonces[thumbprint] ?? [:]
-            jktDomainMap[domain] = nonce
-            jktNonces[thumbprint] = jktDomainMap
-            try? await storage.saveDPoPNoncesByJKT(jktNonces, for: did)
+        var memDomainMap = noncesByThumbprint[resolvedThumbprint] ?? [:]
+        memDomainMap[domain] = nonce
+        noncesByThumbprint[resolvedThumbprint] = memDomainMap
+
+        var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: did)) ?? [:]
+        var jktDomainMap = jktNonces[resolvedThumbprint] ?? [:]
+        jktDomainMap[domain] = nonce
+        jktNonces[resolvedThumbprint] = jktDomainMap
+        do {
+            try await storage.saveDPoPNoncesByJKT(jktNonces, for: did)
+        } catch {
+            // The in-memory map is read first, so this process still uses the fresh
+            // nonce; only the next launch falls back to the DID-scoped copy.
+            LogManager.logWarning(
+                "Failed to persist JKT-scoped DPoP nonce for DID: \(LogManager.logDID(did)), domain: \(domain), error: \(error)",
+                category: .authentication
+            )
+        }
+
+        return true
+    }
+
+    /// The JWK thumbprint of the DID's DPoP key, or `nil` when the key is unavailable
+    /// (e.g. a locked keychain) — the nonce stores are keyed by it.
+    private func dpopKeyThumbprint(for did: String) async -> String? {
+        do {
+            let key = try await getOrCreateDPoPKey(for: did)
+            return try calculateJWKThumbprint(jwk: createJWK(from: key))
+        } catch {
+            LogManager.logError(
+                "Failed to derive DPoP key thumbprint for DID: \(LogManager.logDID(did)): \(error)",
+                category: .authentication
+            )
+            return nil
+        }
+    }
+
+    /// Applies a server-issued nonce for `domain` to all of `did`'s nonce stores.
+    /// - Returns: `false` when the write could not reach the JKT-scoped stores, so a
+    ///   retry would replay the stale nonce the server just rejected.
+    @discardableResult
+    func updateDPoPNonceInternal(domain: String, nonce: String, for did: String) async -> Bool {
+        await writeNonceToAllStores(domain: domain, nonce: nonce, did: did, thumbprint: nil)
+    }
+
+    /// Clears the in-memory nonce caches. Persisted stores are cleared by the caller
+    /// (they are per-DID; these caches are not, so logging one account out drops the
+    /// cached nonces of any other — they are re-learned from a single server challenge).
+    func clearNonceCache() {
+        noncesByThumbprint.removeAll()
+        oauthFlowNonces.removeAll()
+    }
+
+    /// Records a nonce observed during a DID-less OAuth flow, keyed by the endpoint's
+    /// host. `createDPoPProof` reads this map for ephemeral-key proofs, which have no
+    /// account to scope a nonce to yet.
+    func recordOAuthFlowNonce(_ nonce: String, for endpoint: String) {
+        guard let domain = URL(string: endpoint)?.host?.lowercased() else { return }
+        oauthFlowNonces[domain] = nonce
+    }
+
+    /// Moves the nonces collected during the OAuth flow into `did`'s stores, once the
+    /// callback has bound the flow's ephemeral DPoP key to the account. Without this the
+    /// first authenticated request re-learns each nonce through a wasted 400.
+    /// Call after persisting the DPoP key for `did`.
+    func transferOAuthFlowNonces(to did: String) async {
+        guard !oauthFlowNonces.isEmpty else { return }
+        // Take the entries before the first suspension point: the actor can accept
+        // another flow's nonce while the writes below are in flight.
+        let pending = oauthFlowNonces
+        oauthFlowNonces.removeAll()
+
+        let thumbprint = await dpopKeyThumbprint(for: did)
+        for (domain, nonce) in pending {
+            await writeNonceToAllStores(domain: domain, nonce: nonce, did: did, thumbprint: thumbprint)
         }
     }
 
@@ -472,6 +571,7 @@ actor OAuthCore {
             }
             let requestURI = parResponse.requestURI
             let parNonce = extractNonceFromHeaders(httpResponse.allHeaderFields)
+            if let parNonce { recordOAuthFlowNonce(parNonce, for: endpoint) }
             return (requestURI, parNonce)
         } else if httpResponse.statusCode == 400 {
             let dpopNonceHeader = extractNonceFromHeaders(httpResponse.allHeaderFields)
@@ -484,6 +584,7 @@ actor OAuthCore {
 
             if isNonceError, let receivedNonce = dpopNonceHeader {
                 // Retry with nonce
+                recordOAuthFlowNonce(receivedNonce, for: endpoint)
                 var retryRequest = request
                 let retryProof = try await createDPoPProof(
                     for: "POST",
@@ -504,6 +605,7 @@ actor OAuthCore {
                         throw AuthError.invalidResponse
                     }
                     let parNonce = extractNonceFromHeaders(retryHttpResponse.allHeaderFields)
+                    if let parNonce { recordOAuthFlowNonce(parNonce, for: endpoint) }
                     return (parResponse.requestURI, parNonce)
                 } else {
                     throw AuthError.authorizationFailed
@@ -552,23 +654,11 @@ actor OAuthCore {
         }
         guard let resolvedDID = targetDID else { return }
 
-        // Update persistent store
-        var nonces = (try? await storage.getDPoPNonces(for: resolvedDID)) ?? [:]
-        nonces[domain] = nonce
-        try? await storage.saveDPoPNonces(nonces, for: resolvedDID)
-
-        if let jkt {
-            var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: resolvedDID)) ?? [:]
-            var domainMap = jktNonces[jkt] ?? [:]
-            domainMap[domain] = nonce
-            jktNonces[jkt] = domainMap
-            try? await storage.saveDPoPNoncesByJKT(jktNonces, for: resolvedDID)
-
-            // Update memory
-            var memMap = noncesByThumbprint[jkt] ?? [:]
-            memMap[domain] = nonce
-            noncesByThumbprint[jkt] = memMap
-        }
+        // `jkt` is nil for every response the network layer handles without an
+        // AuthContext — notably the token endpoint, whose 200 carries the nonce the
+        // *next* refresh needs. Deriving the thumbprint from the DID's key keeps that
+        // nonce out of the DID-scoped store alone, where the JKT layers would shadow it.
+        await writeNonceToAllStores(domain: domain, nonce: nonce, did: resolvedDID, thumbprint: jkt)
     }
 
     func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {

--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -40,7 +40,11 @@ actor OAuthCore {
     var noncesByThumbprint: [String: [String: String]] = [:]
     var usedRefreshTokens: Set<String> = []
     var activeRefreshTasks: [String: Task<TokenRefreshResult, Error>] = [:]
-    var oauthFlowNonces: [String: String] = [:]
+    /// Nonces observed during OAuth flows that have no account yet, keyed by the
+    /// flow's ephemeral DPoP key thumbprint and then by host. Keying by host alone
+    /// would collide whenever two logins to the same authorization server (the common
+    /// case — everyone's PDS is bsky.social) overlap.
+    var oauthFlowNonces: [String: [String: String]] = [:]
     var ambiguousRefreshUntil: [String: Date] = [:]
     var nextRefreshResourceOverride: String?
 
@@ -53,6 +57,13 @@ actor OAuthCore {
     /// own DPoP key), but `noncesByThumbprint` is keyed by thumbprint alone, so
     /// without this reverse index a clear could only be all-or-nothing.
     var thumbprintsByDID: [String: Set<String>] = [:]
+
+    /// DIDs whose JKT-scoped nonce write could not be persisted (e.g. a locked
+    /// keychain). Their persisted copy is known to be older than what memory holds, so
+    /// a merge may only fill gaps for them instead of letting persistence win —
+    /// otherwise the next merge would reinstate a nonce the server has already
+    /// rejected. Cleared as soon as a persist for that DID succeeds.
+    var didsWithUnpersistedNonces: Set<String> = []
 
     /// How long a merge of the persisted JKT-scoped nonces is trusted before the next
     /// proof re-reads the keychain.
@@ -241,7 +252,7 @@ actor OAuthCore {
                   let urlObject = URL(string: url),
                   let domain = urlObject.host?.lowercased()
         {
-            finalNonce = oauthFlowNonces[domain]
+            finalNonce = oauthFlowNonces[keyThumbprint]?[domain]
         } else if let targetDID = targetDID, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
             // Pick up nonces written by another OAuthCore or another process, letting
             // persistence win. Rate-limited: see `persistedNonceMergeInterval`.
@@ -369,9 +380,13 @@ actor OAuthCore {
         jktNonces[resolvedThumbprint] = jktDomainMap
         do {
             try await storage.saveDPoPNoncesByJKT(jktNonces, for: did)
+            didsWithUnpersistedNonces.remove(did)
         } catch {
             // The in-memory map is read first, so this process still uses the fresh
-            // nonce; only the next launch falls back to the DID-scoped copy.
+            // nonce; only the next launch falls back to the DID-scoped copy. Flagging
+            // the DID stops a later merge from reinstating the older persisted value
+            // over the one just written here.
+            didsWithUnpersistedNonces.insert(did)
             LogManager.logWarning(
                 "Failed to persist JKT-scoped DPoP nonce for DID: \(LogManager.logDID(did)), domain: \(domain), error: \(error)",
                 category: .authentication
@@ -417,9 +432,13 @@ actor OAuthCore {
         lastPersistedNonceMerge[did] = Date()
 
         guard let persistedByJKT = try? await storage.getDPoPNoncesByJKT(for: did) else { return }
+        // Persistence normally wins: it is how a write by another OAuthCore or another
+        // process is observed. The exception is a DID whose own write never reached the
+        // keychain — there the persisted copy is the older one, so memory keeps it.
+        let memoryIsNewer = didsWithUnpersistedNonces.contains(did)
         for (persistedThumbprint, domainMap) in persistedByJKT {
             var merged = noncesByThumbprint[persistedThumbprint] ?? [:]
-            merged.merge(domainMap) { _, new in new } // Persisted values win
+            merged.merge(domainMap) { cached, persisted in memoryIsNewer ? cached : persisted }
             noncesByThumbprint[persistedThumbprint] = merged
             thumbprintsByDID[did, default: []].insert(persistedThumbprint)
         }
@@ -437,14 +456,41 @@ actor OAuthCore {
         }
         thumbprintsByDID.removeValue(forKey: did)
         lastPersistedNonceMerge.removeValue(forKey: did)
+        didsWithUnpersistedNonces.remove(did)
     }
 
-    /// Records a nonce observed during a DID-less OAuth flow, keyed by the endpoint's
-    /// host. `createDPoPProof` reads this map for ephemeral-key proofs, which have no
-    /// account to scope a nonce to yet.
-    func recordOAuthFlowNonce(_ nonce: String, for endpoint: String) {
+    /// Upper bound on the number of in-flight OAuth flows holding a nonce. Flows are
+    /// short-lived and user-driven, so anything past this is abandoned logins whose
+    /// nonces nobody will claim. Past the cap the map is dropped wholesale; a flow that
+    /// was still live simply pays for one `use_dpop_nonce` challenge.
+    private static let oauthFlowNonceKeyCap = 8
+
+    /// Records a nonce observed during an OAuth flow, scoped to the flow's ephemeral
+    /// DPoP key. `createDPoPProof` reads this map for ephemeral-key proofs, which have
+    /// no account to scope a nonce to yet.
+    func recordOAuthFlowNonce(
+        _ nonce: String,
+        for endpoint: String,
+        ephemeralKeyRawRepresentation: Data
+    ) {
+        guard let key = try? P256.Signing.PrivateKey(rawRepresentation: ephemeralKeyRawRepresentation),
+              let thumbprint = try? calculateJWKThumbprint(jwk: createJWK(from: key))
+        else {
+            LogManager.logWarning(
+                "Could not derive a thumbprint for an OAuth flow key; dropping the flow nonce for \(endpoint)",
+                category: .authentication
+            )
+            return
+        }
+        recordOAuthFlowNonce(nonce, for: endpoint, keyThumbprint: thumbprint)
+    }
+
+    func recordOAuthFlowNonce(_ nonce: String, for endpoint: String, keyThumbprint: String) {
         guard let domain = URL(string: endpoint)?.host?.lowercased() else { return }
-        oauthFlowNonces[domain] = nonce
+        if oauthFlowNonces[keyThumbprint] == nil, oauthFlowNonces.count >= Self.oauthFlowNonceKeyCap {
+            oauthFlowNonces.removeAll()
+        }
+        oauthFlowNonces[keyThumbprint, default: [:]][domain] = nonce
     }
 
     /// Moves the nonces collected during the OAuth flow into `did`'s stores, once the
@@ -452,20 +498,18 @@ actor OAuthCore {
     /// first authenticated request re-learns each nonce through a wasted 400.
     /// Call after persisting the DPoP key for `did`.
     ///
-    /// Only the hosts of `endpoints` (this account's authorization server) are moved:
-    /// `oauthFlowNonces` is keyed by host and shared by every flow in progress, so
-    /// draining it wholesale would take a concurrent login's nonce with it.
-    func transferOAuthFlowNonces(to did: String, from endpoints: [String]) async {
-        let hosts = Set(endpoints.compactMap { URL(string: $0)?.host?.lowercased() })
-        // Taken before the first suspension point: the actor can accept another flow's
-        // nonce while the writes below are in flight.
-        let pending = hosts.compactMap { host in oauthFlowNonces[host].map { (host, $0) } }
-        guard !pending.isEmpty else { return }
-        for (host, _) in pending {
-            oauthFlowNonces.removeValue(forKey: host)
+    /// Only this flow's nonces move: they are looked up under the DID's own DPoP
+    /// thumbprint, which at this point is the flow's ephemeral key, so a login running
+    /// concurrently against the same authorization server keeps its own.
+    func transferOAuthFlowNonces(to did: String) async {
+        guard let thumbprint = await dpopKeyThumbprint(for: did),
+              // Taken before the first suspension point below: the actor can accept
+              // another flow's nonce while the writes are in flight.
+              let pending = oauthFlowNonces.removeValue(forKey: thumbprint)
+        else {
+            return
         }
 
-        let thumbprint = await dpopKeyThumbprint(for: did)
         for (domain, nonce) in pending {
             await writeNonceToAllStores(domain: domain, nonce: nonce, did: did, thumbprint: thumbprint)
         }
@@ -619,7 +663,11 @@ actor OAuthCore {
             }
             let requestURI = parResponse.requestURI
             let parNonce = extractNonceFromHeaders(httpResponse.allHeaderFields)
-            if let parNonce { recordOAuthFlowNonce(parNonce, for: endpoint) }
+            if let parNonce {
+                recordOAuthFlowNonce(
+                    parNonce, for: endpoint, ephemeralKeyRawRepresentation: proofKeyRawRepresentation
+                )
+            }
             return (requestURI, parNonce)
         } else if httpResponse.statusCode == 400 {
             let dpopNonceHeader = extractNonceFromHeaders(httpResponse.allHeaderFields)
@@ -632,7 +680,9 @@ actor OAuthCore {
 
             if isNonceError, let receivedNonce = dpopNonceHeader {
                 // Retry with nonce
-                recordOAuthFlowNonce(receivedNonce, for: endpoint)
+                recordOAuthFlowNonce(
+                    receivedNonce, for: endpoint, ephemeralKeyRawRepresentation: proofKeyRawRepresentation
+                )
                 var retryRequest = request
                 let retryProof = try await createDPoPProof(
                     for: "POST",
@@ -653,7 +703,11 @@ actor OAuthCore {
                         throw AuthError.invalidResponse
                     }
                     let parNonce = extractNonceFromHeaders(retryHttpResponse.allHeaderFields)
-                    if let parNonce { recordOAuthFlowNonce(parNonce, for: endpoint) }
+                    if let parNonce {
+                        recordOAuthFlowNonce(
+                            parNonce, for: endpoint, ephemeralKeyRawRepresentation: proofKeyRawRepresentation
+                        )
+                    }
                     return (parResponse.requestURI, parNonce)
                 } else {
                     throw AuthError.authorizationFailed

--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -44,6 +44,27 @@ actor OAuthCore {
     var ambiguousRefreshUntil: [String: Date] = [:]
     var nextRefreshResourceOverride: String?
 
+    /// When each DID's persisted JKT-scoped nonces were last merged into
+    /// `noncesByThumbprint`. Bounds how often a proof re-reads the keychain.
+    var lastPersistedNonceMerge: [String: Date] = [:]
+
+    /// Which thumbprints hold cached nonces for which DID, so one account's logout
+    /// clears exactly its own entries. Thumbprints are per-DID (each account has its
+    /// own DPoP key), but `noncesByThumbprint` is keyed by thumbprint alone, so
+    /// without this reverse index a clear could only be all-or-nothing.
+    var thumbprintsByDID: [String: Set<String>] = [:]
+
+    /// How long a merge of the persisted JKT-scoped nonces is trusted before the next
+    /// proof re-reads the keychain.
+    ///
+    /// This instance is the only writer of its own nonces, so the merge exists solely
+    /// to observe writes by *another* `OAuthCore` (each strategy builds its own) or
+    /// another process in the keychain access group. Missing one of those costs a
+    /// single `use_dpop_nonce` 400, whose handler writes the server's fresh nonce to
+    /// every store — so the staleness is self-correcting and worth trading for one
+    /// keychain read per DID per interval instead of one per outbound request.
+    private static let persistedNonceMergeInterval: TimeInterval = 30
+
     /// Sessions that were successfully refreshed server-side but could not be
     /// persisted to the keychain (e.g. device locked). Held in memory so the
     /// running process keeps working; `getSession`'s pending-key handling covers
@@ -222,17 +243,9 @@ actor OAuthCore {
         {
             finalNonce = oauthFlowNonces[domain]
         } else if let targetDID = targetDID, let urlObject = URL(string: url), let domain = urlObject.host?.lowercased() {
-            // Re-merge the persisted JKT-scoped nonces into memory, letting persistence win.
-            // Every strategy builds its own OAuthCore (and app extensions share the keychain
-            // access group), so another writer can hold a fresher nonce than this actor's
-            // cache — without this merge the stale in-memory entry shadows it.
-            if let persistedByJKT = try? await storage.getDPoPNoncesByJKT(for: targetDID) {
-                for (persistedThumbprint, domainMap) in persistedByJKT {
-                    var merged = noncesByThumbprint[persistedThumbprint] ?? [:]
-                    merged.merge(domainMap) { _, new in new }
-                    noncesByThumbprint[persistedThumbprint] = merged
-                }
-            }
+            // Pick up nonces written by another OAuthCore or another process, letting
+            // persistence win. Rate-limited: see `persistedNonceMergeInterval`.
+            await mergePersistedNoncesIfStale(for: targetDID)
 
             // Multi-layer nonce retrieval: JKT-scoped (in-memory, now including everything
             // persisted above) first, DID-scoped persistence as the fallback.
@@ -348,6 +361,7 @@ actor OAuthCore {
         var memDomainMap = noncesByThumbprint[resolvedThumbprint] ?? [:]
         memDomainMap[domain] = nonce
         noncesByThumbprint[resolvedThumbprint] = memDomainMap
+        thumbprintsByDID[did, default: []].insert(resolvedThumbprint)
 
         var jktNonces = (try? await storage.getDPoPNoncesByJKT(for: did)) ?? [:]
         var jktDomainMap = jktNonces[resolvedThumbprint] ?? [:]
@@ -390,12 +404,39 @@ actor OAuthCore {
         await writeNonceToAllStores(domain: domain, nonce: nonce, did: did, thumbprint: nil)
     }
 
-    /// Clears the in-memory nonce caches. Persisted stores are cleared by the caller
-    /// (they are per-DID; these caches are not, so logging one account out drops the
-    /// cached nonces of any other — they are re-learned from a single server challenge).
-    func clearNonceCache() {
-        noncesByThumbprint.removeAll()
-        oauthFlowNonces.removeAll()
+    /// Merges the persisted JKT-scoped nonces for `did` into memory unless the last
+    /// merge is still within `persistedNonceMergeInterval`.
+    private func mergePersistedNoncesIfStale(for did: String) async {
+        if let mergedAt = lastPersistedNonceMerge[did],
+           Date().timeIntervalSince(mergedAt) < Self.persistedNonceMergeInterval
+        {
+            return
+        }
+        // Stamped before the read so proofs issued concurrently don't all queue their
+        // own keychain round trip behind this one.
+        lastPersistedNonceMerge[did] = Date()
+
+        guard let persistedByJKT = try? await storage.getDPoPNoncesByJKT(for: did) else { return }
+        for (persistedThumbprint, domainMap) in persistedByJKT {
+            var merged = noncesByThumbprint[persistedThumbprint] ?? [:]
+            merged.merge(domainMap) { _, new in new } // Persisted values win
+            noncesByThumbprint[persistedThumbprint] = merged
+            thumbprintsByDID[did, default: []].insert(persistedThumbprint)
+        }
+    }
+
+    /// Clears the in-memory nonce caches belonging to `did`. Persisted stores are
+    /// cleared by the caller. Other accounts' cached nonces are left alone — they are
+    /// keyed by their own DPoP thumbprints and remain valid.
+    ///
+    /// Safe to call after the DID's DPoP key has been deleted: the thumbprints come
+    /// from the reverse index rather than from re-deriving the key.
+    func clearNonceCache(for did: String) {
+        for thumbprint in thumbprintsByDID[did] ?? [] {
+            noncesByThumbprint.removeValue(forKey: thumbprint)
+        }
+        thumbprintsByDID.removeValue(forKey: did)
+        lastPersistedNonceMerge.removeValue(forKey: did)
     }
 
     /// Records a nonce observed during a DID-less OAuth flow, keyed by the endpoint's
@@ -410,12 +451,19 @@ actor OAuthCore {
     /// callback has bound the flow's ephemeral DPoP key to the account. Without this the
     /// first authenticated request re-learns each nonce through a wasted 400.
     /// Call after persisting the DPoP key for `did`.
-    func transferOAuthFlowNonces(to did: String) async {
-        guard !oauthFlowNonces.isEmpty else { return }
-        // Take the entries before the first suspension point: the actor can accept
-        // another flow's nonce while the writes below are in flight.
-        let pending = oauthFlowNonces
-        oauthFlowNonces.removeAll()
+    ///
+    /// Only the hosts of `endpoints` (this account's authorization server) are moved:
+    /// `oauthFlowNonces` is keyed by host and shared by every flow in progress, so
+    /// draining it wholesale would take a concurrent login's nonce with it.
+    func transferOAuthFlowNonces(to did: String, from endpoints: [String]) async {
+        let hosts = Set(endpoints.compactMap { URL(string: $0)?.host?.lowercased() })
+        // Taken before the first suspension point: the actor can accept another flow's
+        // nonce while the writes below are in flight.
+        let pending = hosts.compactMap { host in oauthFlowNonces[host].map { (host, $0) } }
+        guard !pending.isEmpty else { return }
+        for (host, _) in pending {
+            oauthFlowNonces.removeValue(forKey: host)
+        }
 
         let thumbprint = await dpopKeyThumbprint(for: did)
         for (domain, nonce) in pending {

--- a/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
@@ -168,7 +168,14 @@ actor CABOAuthStrategy: AuthStrategy {
         // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
         // during PAR/token exchange are still valid for it — hand them over instead of
         // re-learning each one through a wasted 400 on the first authenticated request.
-        await core.transferOAuthFlowNonces(to: did)
+        await core.transferOAuthFlowNonces(
+            to: did,
+            from: [
+                metadata.tokenEndpoint,
+                metadata.pushedAuthorizationRequestEndpoint,
+                metadata.issuer,
+            ]
+        )
 
         // Create Session
         let session = Session(
@@ -227,10 +234,13 @@ actor CABOAuthStrategy: AuthStrategy {
         try await storage.deleteSession(for: did)
         try await storage.deleteDPoPKey(for: did)
         // Every store `createDPoPProof` reads, or the next login inherits nonces bound
-        // to the DPoP key just deleted.
+        // to the DPoP key just deleted. The in-memory clear is scoped to this DID, so a
+        // second signed-in account keeps its cached nonces. OAuth flow nonces are keyed
+        // by host rather than by account and belong to a flow in progress, so they are
+        // deliberately untouched here.
         try await storage.saveDPoPNonces([:], for: did)
         try await storage.saveDPoPNoncesByJKT([:], for: did)
-        await core.clearNonceCache()
+        await core.clearNonceCache(for: did)
 
         await accountManager.clearCurrentAccount()
     }

--- a/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
@@ -168,14 +168,7 @@ actor CABOAuthStrategy: AuthStrategy {
         // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
         // during PAR/token exchange are still valid for it — hand them over instead of
         // re-learning each one through a wasted 400 on the first authenticated request.
-        await core.transferOAuthFlowNonces(
-            to: did,
-            from: [
-                metadata.tokenEndpoint,
-                metadata.pushedAuthorizationRequestEndpoint,
-                metadata.issuer,
-            ]
-        )
+        await core.transferOAuthFlowNonces(to: did)
 
         // Create Session
         let session = Session(
@@ -571,6 +564,7 @@ actor CABOAuthStrategy: AuthStrategy {
             }
 
             if (200 ..< 300).contains(httpResponse.statusCode) {
+                await recordFlowNonce(from: httpResponse, endpoint: tokenEndpoint, key: key)
                 return try JSONDecoder().decode(TokenResponse.self, from: data)
             } else if httpResponse.statusCode == 400 {
                 // Handle use_dpop_nonce error. The PAR nonce carried in via `nonce` can
@@ -586,6 +580,15 @@ actor CABOAuthStrategy: AuthStrategy {
                 }
 
                 if isNonceError, let receivedNonce = dpopNonceHeader {
+                    // The flow's stored nonce is the one the server just rejected. Replace
+                    // it now, or the callback hands that dead nonce to the new account and
+                    // its first authenticated request pays for another challenge.
+                    await core.recordOAuthFlowNonce(
+                        receivedNonce,
+                        for: tokenEndpoint,
+                        ephemeralKeyRawRepresentation: key.rawRepresentation
+                    )
+
                     let newDpopProof = try await core.createDPoPProof(
                         for: "POST",
                         url: tokenEndpoint,
@@ -604,6 +607,7 @@ actor CABOAuthStrategy: AuthStrategy {
                     else {
                         throw AuthError.tokenRefreshFailed
                     }
+                    await recordFlowNonce(from: retryHttpResponse, endpoint: tokenEndpoint, key: key)
                     return try JSONDecoder().decode(TokenResponse.self, from: retryData)
                 } else {
                     throw AuthError.invalidCredentials
@@ -618,6 +622,19 @@ actor CABOAuthStrategy: AuthStrategy {
         } catch {
             throw AuthError.tokenRefreshFailed
         }
+    }
+
+    /// Keeps the flow's nonce current from a token-endpoint response, so the callback
+    /// hands the freshest nonce to the new account rather than a spent one.
+    private func recordFlowNonce(
+        from response: HTTPURLResponse,
+        endpoint: String,
+        key: P256.Signing.PrivateKey
+    ) async {
+        guard let nonce = await core.extractNonceFromHeaders(response.allHeaderFields) else { return }
+        await core.recordOAuthFlowNonce(
+            nonce, for: endpoint, ephemeralKeyRawRepresentation: key.rawRepresentation
+        )
     }
 
     // MARK: - Token Refresh (Strategy-Specific)

--- a/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
@@ -165,6 +165,11 @@ actor CABOAuthStrategy: AuthStrategy {
         // Persist DPoP Key
         try await storage.saveDPoPKeyRepresentation(ephemeralKey.x963Representation, for: did)
 
+        // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
+        // during PAR/token exchange are still valid for it — hand them over instead of
+        // re-learning each one through a wasted 400 on the first authenticated request.
+        await core.transferOAuthFlowNonces(to: did)
+
         // Create Session
         let session = Session(
             accessToken: tokenResponse.accessToken,
@@ -221,7 +226,11 @@ actor CABOAuthStrategy: AuthStrategy {
 
         try await storage.deleteSession(for: did)
         try await storage.deleteDPoPKey(for: did)
+        // Every store `createDPoPProof` reads, or the next login inherits nonces bound
+        // to the DPoP key just deleted.
         try await storage.saveDPoPNonces([:], for: did)
+        try await storage.saveDPoPNoncesByJKT([:], for: did)
+        await core.clearNonceCache()
 
         await accountManager.clearCurrentAccount()
     }
@@ -553,8 +562,11 @@ actor CABOAuthStrategy: AuthStrategy {
 
             if (200 ..< 300).contains(httpResponse.statusCode) {
                 return try JSONDecoder().decode(TokenResponse.self, from: data)
-            } else if httpResponse.statusCode == 400 && nonce == nil {
-                // Handle use_dpop_nonce error
+            } else if httpResponse.statusCode == 400 {
+                // Handle use_dpop_nonce error. The PAR nonce carried in via `nonce` can
+                // already have rotated by the time the code is exchanged, so this single
+                // retry runs whether or not an initial nonce was supplied — gating it on
+                // `nonce == nil` failed the login outright on a rotated PAR nonce.
                 let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
                 var isNonceError = false
                 if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
@@ -693,9 +705,16 @@ actor CABOAuthStrategy: AuthStrategy {
                errorResponse.error == "use_dpop_nonce",
                let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
             {
-                // Update nonce and retry
-                if let domain = endpointURL.host?.lowercased() {
-                    await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                // Retry only once the fresh nonce is in every store the proof reads —
+                // otherwise the retry replays the nonce the server just rejected.
+                guard let domain = endpointURL.host?.lowercased(),
+                      await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                else {
+                    LogManager.logError(
+                        "Could not apply the server's fresh DPoP nonce for DID: \(LogManager.logDID(did)); skipping the refresh retry that would replay the stale nonce",
+                        category: .authentication
+                    )
+                    return (data, httpResponse)
                 }
 
                 let retryProof = try await core.createDPoPProof(

--- a/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
@@ -190,7 +190,14 @@ actor PublicOAuthStrategy: AuthStrategy {
         // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
         // during PAR/token exchange are still valid for it — hand them over instead of
         // re-learning each one through a wasted 400 on the first authenticated request.
-        await core.transferOAuthFlowNonces(to: did)
+        await core.transferOAuthFlowNonces(
+            to: did,
+            from: [
+                metadata.tokenEndpoint,
+                metadata.pushedAuthorizationRequestEndpoint,
+                metadata.issuer,
+            ]
+        )
 
         // Create Session
         let session = Session(
@@ -249,10 +256,13 @@ actor PublicOAuthStrategy: AuthStrategy {
         try await storage.deleteSession(for: did)
         try await storage.deleteDPoPKey(for: did)
         // Every store `createDPoPProof` reads, or the next login inherits nonces bound
-        // to the DPoP key just deleted.
+        // to the DPoP key just deleted. The in-memory clear is scoped to this DID, so a
+        // second signed-in account keeps its cached nonces. OAuth flow nonces are keyed
+        // by host rather than by account and belong to a flow in progress, so they are
+        // deliberately untouched here.
         try await storage.saveDPoPNonces([:], for: did)
         try await storage.saveDPoPNoncesByJKT([:], for: did)
-        await core.clearNonceCache()
+        await core.clearNonceCache(for: did)
 
         await accountManager.clearCurrentAccount()
     }

--- a/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
@@ -190,14 +190,7 @@ actor PublicOAuthStrategy: AuthStrategy {
         // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
         // during PAR/token exchange are still valid for it — hand them over instead of
         // re-learning each one through a wasted 400 on the first authenticated request.
-        await core.transferOAuthFlowNonces(
-            to: did,
-            from: [
-                metadata.tokenEndpoint,
-                metadata.pushedAuthorizationRequestEndpoint,
-                metadata.issuer,
-            ]
-        )
+        await core.transferOAuthFlowNonces(to: did)
 
         // Create Session
         let session = Session(
@@ -500,6 +493,7 @@ actor PublicOAuthStrategy: AuthStrategy {
             }
 
             if (200 ..< 300).contains(httpResponse.statusCode) {
+                await recordFlowNonce(from: httpResponse, endpoint: tokenEndpoint, key: key)
                 return try JSONDecoder().decode(TokenResponse.self, from: data)
             } else if httpResponse.statusCode == 400 {
                 // Handle use_dpop_nonce error. The PAR nonce carried in via `nonce` can
@@ -515,6 +509,15 @@ actor PublicOAuthStrategy: AuthStrategy {
                 }
 
                 if isNonceError, let receivedNonce = dpopNonceHeader {
+                    // The flow's stored nonce is the one the server just rejected. Replace
+                    // it now, or the callback hands that dead nonce to the new account and
+                    // its first authenticated request pays for another challenge.
+                    await core.recordOAuthFlowNonce(
+                        receivedNonce,
+                        for: tokenEndpoint,
+                        ephemeralKeyRawRepresentation: key.rawRepresentation
+                    )
+
                     let newDpopProof = try await core.createDPoPProof(
                         for: "POST",
                         url: tokenEndpoint,
@@ -533,6 +536,7 @@ actor PublicOAuthStrategy: AuthStrategy {
                     else {
                         throw AuthError.tokenRefreshFailed
                     }
+                    await recordFlowNonce(from: retryHttpResponse, endpoint: tokenEndpoint, key: key)
                     return try JSONDecoder().decode(TokenResponse.self, from: retryData)
                 } else {
                     throw AuthError.invalidCredentials
@@ -547,6 +551,19 @@ actor PublicOAuthStrategy: AuthStrategy {
         } catch {
             throw AuthError.tokenRefreshFailed
         }
+    }
+
+    /// Keeps the flow's nonce current from a token-endpoint response, so the callback
+    /// hands the freshest nonce to the new account rather than a spent one.
+    private func recordFlowNonce(
+        from response: HTTPURLResponse,
+        endpoint: String,
+        key: P256.Signing.PrivateKey
+    ) async {
+        guard let nonce = await core.extractNonceFromHeaders(response.allHeaderFields) else { return }
+        await core.recordOAuthFlowNonce(
+            nonce, for: endpoint, ephemeralKeyRawRepresentation: key.rawRepresentation
+        )
     }
 
     // MARK: - Token Refresh (Strategy-Specific)

--- a/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
@@ -187,6 +187,11 @@ actor PublicOAuthStrategy: AuthStrategy {
         // Persist DPoP Key
         try await storage.saveDPoPKeyRepresentation(ephemeralKey.x963Representation, for: did)
 
+        // The flow's ephemeral key is now this DID's DPoP key, so the nonces learned
+        // during PAR/token exchange are still valid for it — hand them over instead of
+        // re-learning each one through a wasted 400 on the first authenticated request.
+        await core.transferOAuthFlowNonces(to: did)
+
         // Create Session
         let session = Session(
             accessToken: tokenResponse.accessToken,
@@ -243,7 +248,11 @@ actor PublicOAuthStrategy: AuthStrategy {
 
         try await storage.deleteSession(for: did)
         try await storage.deleteDPoPKey(for: did)
+        // Every store `createDPoPProof` reads, or the next login inherits nonces bound
+        // to the DPoP key just deleted.
         try await storage.saveDPoPNonces([:], for: did)
+        try await storage.saveDPoPNoncesByJKT([:], for: did)
+        await core.clearNonceCache()
 
         await accountManager.clearCurrentAccount()
     }
@@ -482,8 +491,11 @@ actor PublicOAuthStrategy: AuthStrategy {
 
             if (200 ..< 300).contains(httpResponse.statusCode) {
                 return try JSONDecoder().decode(TokenResponse.self, from: data)
-            } else if httpResponse.statusCode == 400 && nonce == nil {
-                // Handle use_dpop_nonce error
+            } else if httpResponse.statusCode == 400 {
+                // Handle use_dpop_nonce error. The PAR nonce carried in via `nonce` can
+                // already have rotated by the time the code is exchanged, so this single
+                // retry runs whether or not an initial nonce was supplied — gating it on
+                // `nonce == nil` failed the login outright on a rotated PAR nonce.
                 let dpopNonceHeader = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
                 var isNonceError = false
                 if let errorResponse = try? JSONDecoder().decode(OAuthErrorResponse.self, from: data),
@@ -618,9 +630,16 @@ actor PublicOAuthStrategy: AuthStrategy {
                errorResponse.error == "use_dpop_nonce",
                let receivedNonce = await core.extractNonceFromHeaders(httpResponse.allHeaderFields)
             {
-                // Update nonce and retry
-                if let domain = endpointURL.host?.lowercased() {
-                    await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                // Retry only once the fresh nonce is in every store the proof reads —
+                // otherwise the retry replays the nonce the server just rejected.
+                guard let domain = endpointURL.host?.lowercased(),
+                      await core.updateDPoPNonceInternal(domain: domain, nonce: receivedNonce, for: did)
+                else {
+                    LogManager.logError(
+                        "Could not apply the server's fresh DPoP nonce for DID: \(LogManager.logDID(did)); skipping the refresh retry that would replay the stale nonce",
+                        category: .authentication
+                    )
+                    return (data, httpResponse)
                 }
 
                 let retryProof = try await core.createDPoPProof(

--- a/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
+++ b/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
@@ -188,7 +188,7 @@ struct DPoPNonceStoreTests {
         }
     }
 
-    @Test("A persisted nonce wins over a stale in-memory one from another core")
+    @Test("A merge lets a persisted nonce win over a stale in-memory one")
     func persistedNonceWinsOverStaleMemory() async throws {
         let backend = InMemorySecureStorage()
         try await withInMemoryStorage(backend) {
@@ -211,6 +211,38 @@ struct DPoPNonceStoreTests {
 
             let proofNonce = try await nonceInProof(from: staleCore)
             #expect(proofNonce == "fresh")
+        }
+    }
+
+    @Test("Within the merge interval a proof reuses the nonce it already holds")
+    func mergeIntervalBoundsPersistenceReads() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.merge-interval")
+            let core = makeCore(storage: storage)
+            let otherCore = makeCore(storage: storage)
+            try await installDPoPKey(storage: storage, core: core)
+
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "first", for: Self.did)
+            // This proof merges persistence and starts the interval.
+            let firstProofNonce = try await nonceInProof(from: core)
+            #expect(firstProofNonce == "first")
+
+            await otherCore.updateDPoPNonceInternal(
+                domain: Self.host, nonce: "second", for: Self.did
+            )
+
+            // The documented staleness window: within the interval this core keeps
+            // signing with the nonce it already holds instead of re-reading. A server
+            // that has moved on answers use_dpop_nonce, and that handler writes the
+            // fresh nonce to every store — so the window is self-correcting.
+            let cachedProofNonce = try await nonceInProof(from: core)
+            #expect(cachedProofNonce == "first")
+
+            // Persistence really does hold the newer value: a core that has not merged
+            // yet picks it up on its first proof.
+            let freshProofNonce = try await nonceInProof(from: makeCore(storage: storage))
+            #expect(freshProofNonce == "second")
         }
     }
 
@@ -238,18 +270,53 @@ struct DPoPNonceStoreTests {
                 makeAccount(), session: makeSession(), for: Self.did
             )
             await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
-            await core.recordOAuthFlowNonce("flow-stale", for: Self.endpoint)
 
             try await strategy.logout()
 
             let didNonces = try await storage.getDPoPNonces(for: Self.did)
             let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
             let cached = await core.noncesByThumbprint
-            let flowNonces = await core.oauthFlowNonces
             #expect(didNonces?.isEmpty != false)
             #expect(jktNonces?.isEmpty != false)
             #expect(cached[thumbprint] == nil)
-            #expect(flowNonces.isEmpty)
+        }
+    }
+
+    @Test("Logging one account out leaves another account's cached nonces intact")
+    func logoutIsScopedToTheAccountLoggingOut() async throws {
+        let backend = InMemorySecureStorage()
+        let otherDID = "did:plc:noncestore-other"
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.scoped-logout")
+            let strategy = PublicOAuthStrategy(
+                storage: storage,
+                accountManager: MockAccountManager(account: makeAccount()),
+                networkService: NetworkService(baseURL: URL(string: "https://pds.test")!),
+                oauthConfig: OAuthConfig(
+                    clientId: "https://client.example/oauth-client-metadata.json",
+                    redirectUri: "https://client.example/callback",
+                    scope: "atproto"
+                ),
+                didResolver: MockDIDResolver()
+            )
+            let core = await strategy.core
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+            let otherThumbprint = try await installDPoPKey(
+                storage: storage, core: core, did: otherDID
+            )
+            try await storage.saveAccountAndSession(
+                makeAccount(), session: makeSession(), for: Self.did
+            )
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "other", for: otherDID)
+
+            try await strategy.logout()
+
+            let cached = await core.noncesByThumbprint
+            let otherPersisted = try await storage.getDPoPNoncesByJKT(for: otherDID)
+            #expect(cached[thumbprint] == nil)
+            #expect(cached[otherThumbprint]?[Self.host] == "other")
+            #expect(otherPersisted?[otherThumbprint]?[Self.host] == "other")
         }
     }
 
@@ -325,10 +392,12 @@ struct DPoPNonceStoreTests {
 
             // What `pushAuthorizationRequest` records before any DID exists.
             await core.recordOAuthFlowNonce("par-nonce", for: Self.endpoint)
+            // A second login to a different authorization server, still in flight.
+            await core.recordOAuthFlowNonce("other-par-nonce", for: "https://auth.other.test/par")
             let recorded = await core.oauthFlowNonces
             #expect(recorded[Self.host] == "par-nonce")
 
-            await core.transferOAuthFlowNonces(to: Self.did)
+            await core.transferOAuthFlowNonces(to: Self.did, from: [Self.endpoint])
 
             let didNonces = try await storage.getDPoPNonces(for: Self.did)
             let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
@@ -336,7 +405,9 @@ struct DPoPNonceStoreTests {
             let proofNonce = try await nonceInProof(from: core)
             #expect(didNonces?[Self.host] == "par-nonce")
             #expect(jktNonces?[thumbprint]?[Self.host] == "par-nonce")
-            #expect(remainingFlowNonces.isEmpty)
+            #expect(remainingFlowNonces[Self.host] == nil)
+            // The concurrent flow's nonce is left for the login that is still using it.
+            #expect(remainingFlowNonces["auth.other.test"] == "other-par-nonce")
             #expect(proofNonce == "par-nonce")
         }
     }

--- a/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
+++ b/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
@@ -23,6 +23,21 @@ private func withInMemoryStorage<T>(
     }
 }
 
+/// The `nonce` claim of a compact DPoP proof.
+private func nonceInProofString(_ compactJWS: String) throws -> String? {
+    let parts = compactJWS.split(separator: ".")
+    try #require(parts.count == 3)
+    var encoded = String(parts[1])
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    while encoded.count % 4 != 0 {
+        encoded += "="
+    }
+    let data = try #require(Data(base64Encoded: encoded))
+    let payload = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    return payload["nonce"] as? String
+}
+
 /// Covers the invariant that every write of a DPoP nonce reaches all three stores
 /// `OAuthCore.createDPoPProof` reads (in-memory JKT map, persisted JKT map,
 /// persisted DID map), and that every clear empties all of them. A write landing
@@ -92,17 +107,7 @@ struct DPoPNonceStoreTests {
             type: .tokenRefresh,
             did: did
         )
-        let parts = proof.split(separator: ".")
-        try #require(parts.count == 3)
-        var encoded = String(parts[1])
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        while encoded.count % 4 != 0 {
-            encoded += "="
-        }
-        let data = try #require(Data(base64Encoded: encoded))
-        let payload = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
-        return payload["nonce"] as? String
+        return try nonceInProofString(proof)
     }
 
     // MARK: - Writes
@@ -211,6 +216,32 @@ struct DPoPNonceStoreTests {
 
             let proofNonce = try await nonceInProof(from: staleCore)
             #expect(proofNonce == "fresh")
+        }
+    }
+
+    @Test("A merge cannot reinstate a persisted nonce over one that failed to persist")
+    func mergeDoesNotClobberAnUnpersistedNonce() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.unpersisted-write")
+            let core = makeCore(storage: storage)
+            try await installDPoPKey(storage: storage, core: core)
+
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "first", for: Self.did)
+
+            // The keychain goes read-only (device locked) and the server hands out a new
+            // nonce: memory has it, persistence still holds the one just rejected.
+            backend.failStoreMatching = { $0.hasPrefix("dpopNoncesByJKT.") }
+            defer { backend.failStoreMatching = nil }
+            let applied = await core.updateDPoPNonceInternal(
+                domain: Self.host, nonce: "second", for: Self.did
+            )
+            #expect(applied)
+
+            // This proof merges persistence. It must not restore "first" over the newer
+            // in-memory value, or the retry replays the nonce the server rejected.
+            let proofNonce = try await nonceInProof(from: core)
+            #expect(proofNonce == "second")
         }
     }
 
@@ -390,14 +421,24 @@ struct DPoPNonceStoreTests {
             let core = makeCore(storage: storage)
             let thumbprint = try await installDPoPKey(storage: storage, core: core)
 
-            // What `pushAuthorizationRequest` records before any DID exists.
-            await core.recordOAuthFlowNonce("par-nonce", for: Self.endpoint)
-            // A second login to a different authorization server, still in flight.
-            await core.recordOAuthFlowNonce("other-par-nonce", for: "https://auth.other.test/par")
-            let recorded = await core.oauthFlowNonces
-            #expect(recorded[Self.host] == "par-nonce")
+            // What `pushAuthorizationRequest` records before any DID exists. This flow's
+            // ephemeral key is the one already installed for the DID.
+            await core.recordOAuthFlowNonce(
+                "par-nonce", for: Self.endpoint, keyThumbprint: thumbprint
+            )
+            // A second login to the *same* authorization server, still in flight, under
+            // its own ephemeral key.
+            let otherFlowKey = P256.Signing.PrivateKey()
+            let otherFlowThumbprint = try await core.calculateJWKThumbprint(
+                jwk: core.createJWK(from: otherFlowKey)
+            )
+            await core.recordOAuthFlowNonce(
+                "other-flow-nonce",
+                for: Self.endpoint,
+                ephemeralKeyRawRepresentation: otherFlowKey.rawRepresentation
+            )
 
-            await core.transferOAuthFlowNonces(to: Self.did, from: [Self.endpoint])
+            await core.transferOAuthFlowNonces(to: Self.did)
 
             let didNonces = try await storage.getDPoPNonces(for: Self.did)
             let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
@@ -405,10 +446,48 @@ struct DPoPNonceStoreTests {
             let proofNonce = try await nonceInProof(from: core)
             #expect(didNonces?[Self.host] == "par-nonce")
             #expect(jktNonces?[thumbprint]?[Self.host] == "par-nonce")
-            #expect(remainingFlowNonces[Self.host] == nil)
-            // The concurrent flow's nonce is left for the login that is still using it.
-            #expect(remainingFlowNonces["auth.other.test"] == "other-par-nonce")
+            #expect(remainingFlowNonces[thumbprint] == nil)
+            // The concurrent flow keeps its own nonce even on the same host.
+            #expect(remainingFlowNonces[otherFlowThumbprint]?[Self.host] == "other-flow-nonce")
             #expect(proofNonce == "par-nonce")
+        }
+    }
+
+    @Test("Two flows on the same host keep separate nonces")
+    func concurrentSameHostFlowsDoNotShareNonces() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.same-host-flows")
+            let core = makeCore(storage: storage)
+            let firstKey = P256.Signing.PrivateKey()
+            let secondKey = P256.Signing.PrivateKey()
+
+            await core.recordOAuthFlowNonce(
+                "first-flow-nonce",
+                for: Self.endpoint,
+                ephemeralKeyRawRepresentation: firstKey.rawRepresentation
+            )
+            await core.recordOAuthFlowNonce(
+                "second-flow-nonce",
+                for: Self.endpoint,
+                ephemeralKeyRawRepresentation: secondKey.rawRepresentation
+            )
+
+            // Each flow signs with the nonce its own PAR response returned.
+            let firstProof = try await core.createDPoPProof(
+                for: "POST",
+                url: Self.endpoint,
+                type: .tokenRequest,
+                ephemeralKeyRawRepresentation: firstKey.rawRepresentation
+            )
+            let secondProof = try await core.createDPoPProof(
+                for: "POST",
+                url: Self.endpoint,
+                type: .tokenRequest,
+                ephemeralKeyRawRepresentation: secondKey.rawRepresentation
+            )
+            #expect(try nonceInProofString(firstProof) == "first-flow-nonce")
+            #expect(try nonceInProofString(secondProof) == "second-flow-nonce")
         }
     }
 }

--- a/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
+++ b/Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift
@@ -1,0 +1,343 @@
+#if canImport(CryptoKit)
+    import CryptoKit
+#else
+    @preconcurrency import Crypto
+#endif
+import Foundation
+@testable import Petrel
+import Testing
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+/// Runs `body` with an injected in-memory storage backend, always restoring the
+/// platform default afterwards.
+private func withInMemoryStorage<T>(
+    _ backend: InMemorySecureStorage,
+    _ body: () async throws -> T
+) async throws -> T {
+    try await withSerializedStorageOverrideTest {
+        KeychainManager._setStorageOverride(backend)
+        defer { KeychainManager._setStorageOverride(nil) }
+        return try await body()
+    }
+}
+
+/// Covers the invariant that every write of a DPoP nonce reaches all three stores
+/// `OAuthCore.createDPoPProof` reads (in-memory JKT map, persisted JKT map,
+/// persisted DID map), and that every clear empties all of them. A write landing
+/// only in the DID-scoped store is shadowed by the JKT-scoped layers, which is how
+/// a session ends up replaying a nonce the server already rejected.
+@Suite("DPoP nonce store consistency", .serialized)
+struct DPoPNonceStoreTests {
+    private static let did = "did:plc:noncestore"
+    private static let host = "auth.nonce.test"
+    private static let endpoint = "https://auth.nonce.test/oauth/token"
+
+    // MARK: - Fixtures
+
+    private func makeCore(storage: KeychainStorage, did: String = did) -> OAuthCore {
+        OAuthCore(
+            storage: storage,
+            accountManager: MockAccountManager(account: makeAccount(did: did)),
+            networkService: NetworkService(baseURL: URL(string: "https://pds.test")!),
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/oauth-client-metadata.json",
+                redirectUri: "https://client.example/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver()
+        )
+    }
+
+    private func makeAccount(did: String = did) -> Account {
+        Account(
+            did: did,
+            handle: "nonce.example",
+            pdsURL: URL(string: "https://pds.test")!
+        )
+    }
+
+    private func makeSession(did: String = did) -> Session {
+        Session(
+            accessToken: "access",
+            refreshToken: "refresh",
+            createdAt: Date(),
+            expiresIn: 3600,
+            tokenType: .dpop,
+            did: did
+        )
+    }
+
+    /// Installs a DPoP key for `did` and returns its JWK thumbprint — the key the
+    /// JKT-scoped stores are keyed by.
+    @discardableResult
+    private func installDPoPKey(
+        storage: KeychainStorage,
+        core: OAuthCore,
+        did: String = did
+    ) async throws -> String {
+        let key = P256.Signing.PrivateKey()
+        try await storage.saveDPoPKeyRepresentation(key.x963Representation, for: did)
+        let jwk = try await core.createJWK(from: key)
+        return try await core.calculateJWKThumbprint(jwk: jwk)
+    }
+
+    /// The nonce a freshly minted proof actually carries — the only check that covers
+    /// the whole read precedence rather than one store in isolation.
+    private func nonceInProof(from core: OAuthCore, did: String = did) async throws -> String? {
+        let proof = try await core.createDPoPProof(
+            for: "POST",
+            url: Self.endpoint,
+            type: .tokenRefresh,
+            did: did
+        )
+        let parts = proof.split(separator: ".")
+        try #require(parts.count == 3)
+        var encoded = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while encoded.count % 4 != 0 {
+            encoded += "="
+        }
+        let data = try #require(Data(base64Encoded: encoded))
+        let payload = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return payload["nonce"] as? String
+    }
+
+    // MARK: - Writes
+
+    @Test("A nonce update without a JKT still reaches all three stores")
+    func updateWithoutJKTWritesAllStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.jkt-nil-write")
+            let core = makeCore(storage: storage)
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+
+            // A stale JKT-scoped nonce of the kind login leaves behind — it shadows any
+            // write that reaches the DID-scoped store alone.
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
+
+            // The token endpoint's response carries no AuthContext, so jkt is nil.
+            await core.updateDPoPNonce(
+                for: URL(string: Self.endpoint)!,
+                from: ["DPoP-Nonce": "fresh"],
+                did: Self.did,
+                jkt: nil
+            )
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            let cached = await core.noncesByThumbprint
+            let proofNonce = try await nonceInProof(from: core)
+            #expect(didNonces?[Self.host] == "fresh")
+            #expect(jktNonces?[thumbprint]?[Self.host] == "fresh")
+            #expect(cached[thumbprint]?[Self.host] == "fresh")
+            #expect(proofNonce == "fresh")
+        }
+    }
+
+    @Test("A nonce update with an explicit JKT writes that thumbprint's stores")
+    func updateWithJKTWritesAllStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.jkt-explicit-write")
+            let core = makeCore(storage: storage)
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+
+            await core.updateDPoPNonce(
+                for: URL(string: Self.endpoint)!,
+                from: ["dpop-nonce": "fresh"],
+                did: Self.did,
+                jkt: thumbprint
+            )
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            let proofNonce = try await nonceInProof(from: core)
+            #expect(didNonces?[Self.host] == "fresh")
+            #expect(jktNonces?[thumbprint]?[Self.host] == "fresh")
+            #expect(proofNonce == "fresh")
+        }
+    }
+
+    @Test("A write that cannot resolve the thumbprint reports failure")
+    func writeReportsFailureWhenThumbprintUnavailable() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.unreadable-key")
+            let core = makeCore(storage: storage)
+            // An unreadable DPoP key (locked keychain, corrupt entry) leaves the
+            // JKT-scoped stores untouched, so a retry would replay the stale nonce.
+            backend.plant(
+                key: "dpopKey.\(Self.did)",
+                namespace: "dpopkeys",
+                data: Data([0x00])
+            )
+
+            let applied = await core.updateDPoPNonceInternal(
+                domain: Self.host, nonce: "fresh", for: Self.did
+            )
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            #expect(applied == false)
+            #expect(didNonces?[Self.host] == "fresh")
+            #expect(jktNonces?.isEmpty != false)
+        }
+    }
+
+    @Test("A persisted nonce wins over a stale in-memory one from another core")
+    func persistedNonceWinsOverStaleMemory() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.persistence-merge")
+            let staleCore = makeCore(storage: storage)
+            let freshCore = makeCore(storage: storage)
+            let thumbprint = try await installDPoPKey(storage: storage, core: staleCore)
+
+            await staleCore.updateDPoPNonceInternal(
+                domain: Self.host, nonce: "stale", for: Self.did
+            )
+            let staleCache = await staleCore.noncesByThumbprint
+            #expect(staleCache[thumbprint]?[Self.host] == "stale")
+
+            // A second OAuthCore over the same storage — every strategy builds its own —
+            // records a newer nonce.
+            await freshCore.updateDPoPNonceInternal(
+                domain: Self.host, nonce: "fresh", for: Self.did
+            )
+
+            let proofNonce = try await nonceInProof(from: staleCore)
+            #expect(proofNonce == "fresh")
+        }
+    }
+
+    // MARK: - Clears
+
+    @Test("Public strategy logout clears every nonce store")
+    func publicLogoutClearsNonceStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.public-logout")
+            let strategy = PublicOAuthStrategy(
+                storage: storage,
+                accountManager: MockAccountManager(account: makeAccount()),
+                networkService: NetworkService(baseURL: URL(string: "https://pds.test")!),
+                oauthConfig: OAuthConfig(
+                    clientId: "https://client.example/oauth-client-metadata.json",
+                    redirectUri: "https://client.example/callback",
+                    scope: "atproto"
+                ),
+                didResolver: MockDIDResolver()
+            )
+            let core = await strategy.core
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+            try await storage.saveAccountAndSession(
+                makeAccount(), session: makeSession(), for: Self.did
+            )
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
+            await core.recordOAuthFlowNonce("flow-stale", for: Self.endpoint)
+
+            try await strategy.logout()
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            let cached = await core.noncesByThumbprint
+            let flowNonces = await core.oauthFlowNonces
+            #expect(didNonces?.isEmpty != false)
+            #expect(jktNonces?.isEmpty != false)
+            #expect(cached[thumbprint] == nil)
+            #expect(flowNonces.isEmpty)
+        }
+    }
+
+    @Test("CAB strategy logout clears every nonce store")
+    func cabLogoutClearsNonceStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.cab-logout")
+            let strategy = CABOAuthStrategy(
+                backendURL: URL(string: "https://cab.example.com")!,
+                storage: storage,
+                accountManager: MockAccountManager(account: makeAccount()),
+                networkService: NetworkService(baseURL: URL(string: "https://pds.test")!),
+                oauthConfig: OAuthConfig(
+                    clientId: "https://cab.example.com/oauth-client-metadata.json",
+                    redirectUri: "https://client.example/callback",
+                    scope: "atproto"
+                ),
+                didResolver: MockDIDResolver(),
+                urlSession: URLSession(configuration: .ephemeral)
+            )
+            let core = await strategy.core
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+            try await storage.saveAccountAndSession(
+                makeAccount(), session: makeSession(), for: Self.did
+            )
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
+
+            try await strategy.logout()
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            let cached = await core.noncesByThumbprint
+            #expect(didNonces?.isEmpty != false)
+            #expect(jktNonces?.isEmpty != false)
+            #expect(cached[thumbprint] == nil)
+        }
+    }
+
+    @Test("Removing an account clears its nonce stores")
+    func removeAccountClearsNonceStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.remove-account")
+            let core = makeCore(storage: storage)
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+            try await storage.saveAccountAndSession(
+                makeAccount(), session: makeSession(), for: Self.did
+            )
+            await core.updateDPoPNonceInternal(domain: Self.host, nonce: "stale", for: Self.did)
+            let seeded = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            #expect(seeded?[thumbprint]?[Self.host] == "stale")
+
+            let accountManager = await AccountManager(storage: storage)
+            try await accountManager.removeAccount(did: Self.did)
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            #expect(didNonces?.isEmpty != false)
+            #expect(jktNonces?.isEmpty != false)
+        }
+    }
+
+    // MARK: - OAuth flow nonces
+
+    @Test("Flow nonces move to the DID's stores once login binds the key")
+    func flowNoncesTransferToDIDStores() async throws {
+        let backend = InMemorySecureStorage()
+        try await withInMemoryStorage(backend) {
+            let storage = KeychainStorage(namespace: "test.nonce.flow-transfer")
+            let core = makeCore(storage: storage)
+            let thumbprint = try await installDPoPKey(storage: storage, core: core)
+
+            // What `pushAuthorizationRequest` records before any DID exists.
+            await core.recordOAuthFlowNonce("par-nonce", for: Self.endpoint)
+            let recorded = await core.oauthFlowNonces
+            #expect(recorded[Self.host] == "par-nonce")
+
+            await core.transferOAuthFlowNonces(to: Self.did)
+
+            let didNonces = try await storage.getDPoPNonces(for: Self.did)
+            let jktNonces = try await storage.getDPoPNoncesByJKT(for: Self.did)
+            let remainingFlowNonces = await core.oauthFlowNonces
+            let proofNonce = try await nonceInProof(from: core)
+            #expect(didNonces?[Self.host] == "par-nonce")
+            #expect(jktNonces?[thumbprint]?[Self.host] == "par-nonce")
+            #expect(remainingFlowNonces.isEmpty)
+            #expect(proofNonce == "par-nonce")
+        }
+    }
+}

--- a/Tests/PetrelTests/Auth/OAuthTokenExchangeNonceTests.swift
+++ b/Tests/PetrelTests/Auth/OAuthTokenExchangeNonceTests.swift
@@ -69,6 +69,7 @@ private final class OAuthFlowURLProtocol: URLProtocol {
 private let pdsHost = "https://pds.exchange.test"
 private let authHost = "https://auth.exchange.test"
 private let tokenEndpoint = "\(authHost)/oauth/token"
+private let authServerHost = "auth.exchange.test"
 
 private func jsonResponse(
     url: URL,
@@ -274,6 +275,15 @@ struct OAuthTokenExchangeNonceTests {
             let secondNonce = try nonceInProof(#require(proofs.last))
             #expect(firstNonce == initialPARNonce)
             #expect(secondNonce == "server-nonce")
+
+            // The account inherits the nonce the server accepted, not the one it
+            // rejected — otherwise the first authenticated request pays for another
+            // use_dpop_nonce round trip.
+            let storedNonces = try await storage.getDPoPNonces(for: result.did)
+            let storedByJKT = try await storage.getDPoPNoncesByJKT(for: result.did)
+            let thumbprint = try #require(storedByJKT?.keys.first)
+            #expect(storedNonces?[authServerHost] == "server-nonce")
+            #expect(storedByJKT?[thumbprint]?[authServerHost] == "server-nonce")
         }
     }
 }

--- a/Tests/PetrelTests/Auth/OAuthTokenExchangeNonceTests.swift
+++ b/Tests/PetrelTests/Auth/OAuthTokenExchangeNonceTests.swift
@@ -1,0 +1,279 @@
+#if canImport(CryptoKit)
+    import CryptoKit
+#else
+    @preconcurrency import Crypto
+#endif
+import Foundation
+@testable import Petrel
+import Testing
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+// MARK: - Transport
+
+/// Records the DPoP proof of every token-endpoint request so a test can tell how
+/// many exchanges happened and which nonce each one carried.
+private final class TokenEndpointRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var proofs: [String] = []
+
+    func record(proof: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        proofs.append(proof)
+    }
+
+    var recordedProofs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return proofs
+    }
+}
+
+/// URLProtocol serving an authorization server: both metadata documents and a token
+/// endpoint scripted by the installed handler. Separate from `MockURLProtocol` so the
+/// two suites can never fight over one global handler.
+private final class OAuthFlowURLProtocol: URLProtocol {
+    private nonisolated(unsafe) static var handler: (@Sendable (URLRequest) -> (HTTPURLResponse, Data))?
+    private static let handlerLock = NSLock()
+
+    static func setHandler(_ new: (@Sendable (URLRequest) -> (HTTPURLResponse, Data))?) {
+        handlerLock.withLock { handler = new }
+    }
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handlerLock.withLock({ Self.handler }) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let (response, data) = handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Fixtures
+
+private let pdsHost = "https://pds.exchange.test"
+private let authHost = "https://auth.exchange.test"
+private let tokenEndpoint = "\(authHost)/oauth/token"
+
+private func jsonResponse(
+    url: URL,
+    status: Int,
+    headers: [String: String] = [:]
+) -> HTTPURLResponse {
+    var allHeaders = headers
+    allHeaders["Content-Type"] = "application/json"
+    return HTTPURLResponse(
+        url: url,
+        statusCode: status,
+        httpVersion: "HTTP/1.1",
+        headerFields: allHeaders
+    )!
+}
+
+private let protectedResourceJSON = """
+{
+  "resource": "\(pdsHost)",
+  "authorization_servers": ["\(authHost)"],
+  "scopes_supported": ["atproto"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "\(pdsHost)/docs"
+}
+"""
+
+private let authServerJSON = """
+{
+  "issuer": "\(authHost)",
+  "scopes_supported": ["atproto"],
+  "subject_types_supported": ["public"],
+  "response_types_supported": ["code"],
+  "response_modes_supported": ["query"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"],
+  "ui_locales_supported": ["en-US"],
+  "display_values_supported": ["page"],
+  "authorization_response_iss_parameter_supported": true,
+  "request_object_signing_alg_values_supported": ["ES256"],
+  "request_object_encryption_alg_values_supported": [],
+  "request_object_encryption_enc_values_supported": [],
+  "request_parameter_supported": true,
+  "request_uri_parameter_supported": true,
+  "require_request_uri_registration": true,
+  "jwks_uri": "\(authHost)/oauth/jwks",
+  "authorization_endpoint": "\(authHost)/oauth/authorize",
+  "token_endpoint": "\(tokenEndpoint)",
+  "token_endpoint_auth_methods_supported": ["none"],
+  "token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+  "revocation_endpoint": "\(authHost)/oauth/revoke",
+  "pushed_authorization_request_endpoint": "\(authHost)/oauth/par",
+  "require_pushed_authorization_requests": true,
+  "dpop_signing_alg_values_supported": ["ES256"],
+  "client_id_metadata_document_supported": true
+}
+"""
+
+private let tokenJSON = """
+{
+  "access_token": "access-token",
+  "token_type": "DPoP",
+  "expires_in": 3600,
+  "refresh_token": "refresh-token",
+  "scope": "atproto",
+  "sub": "did:plc:parnoncerotation"
+}
+"""
+
+private let useDPoPNonceJSON = """
+{"error":"use_dpop_nonce","error_description":"Authorization server requires nonce in DPoP proof"}
+"""
+
+private func nonceInProof(_ compactJWS: String) throws -> String? {
+    let parts = compactJWS.split(separator: ".")
+    try #require(parts.count == 3)
+    var encoded = String(parts[1])
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    while encoded.count % 4 != 0 {
+        encoded += "="
+    }
+    let data = try #require(Data(base64Encoded: encoded))
+    let payload = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    return payload["nonce"] as? String
+}
+
+/// Runs `body` with an in-memory keychain and the OAuth flow transport installed.
+private func withOAuthFlowTransport<T>(
+    _ backend: InMemorySecureStorage,
+    handler: @escaping @Sendable (URLRequest) -> (HTTPURLResponse, Data),
+    _ body: () async throws -> T
+) async throws -> T {
+    try await withSerializedStorageOverrideTest {
+        KeychainManager._setStorageOverride(backend)
+        OAuthFlowURLProtocol.setHandler(handler)
+        NetworkService.setNetworkTestProtocolClasses([OAuthFlowURLProtocol.self])
+        defer {
+            NetworkService.setNetworkTestProtocolClasses(nil)
+            OAuthFlowURLProtocol.setHandler(nil)
+            KeychainManager._setStorageOverride(nil)
+        }
+        return try await body()
+    }
+}
+
+// MARK: - Tests
+
+/// The authorization server can rotate the DPoP nonce between the pushed
+/// authorization request and the token exchange. The exchange must spend its one
+/// `use_dpop_nonce` retry on the server's nonce whether or not it started out with a
+/// PAR nonce — gating the retry on "no initial nonce" made a rotated PAR nonce fail
+/// the login outright.
+@Suite("OAuth token exchange nonce handling", .serialized)
+struct OAuthTokenExchangeNonceTests {
+    private func makeStrategy(namespace: String) -> PublicOAuthStrategy {
+        PublicOAuthStrategy(
+            storage: KeychainStorage(namespace: namespace),
+            accountManager: MockAccountManager(
+                account: Account(
+                    did: "did:plc:parnoncerotation",
+                    handle: "exchange.example",
+                    pdsURL: URL(string: pdsHost)!
+                )
+            ),
+            networkService: NetworkService(baseURL: URL(string: pdsHost)!),
+            oauthConfig: OAuthConfig(
+                clientId: "https://client.example/oauth-client-metadata.json",
+                redirectUri: "https://client.example/callback",
+                scope: "atproto"
+            ),
+            didResolver: MockDIDResolver()
+        )
+    }
+
+    /// Answers the metadata documents, then the token endpoint: `use_dpop_nonce` first,
+    /// tokens second.
+    private func makeHandler(
+        recorder: TokenEndpointRecorder
+    ) -> @Sendable (URLRequest) -> (HTTPURLResponse, Data) {
+        { request in
+            let url = request.url!
+            switch url.path {
+            case "/.well-known/oauth-protected-resource":
+                return (jsonResponse(url: url, status: 200), Data(protectedResourceJSON.utf8))
+            case "/.well-known/oauth-authorization-server":
+                return (jsonResponse(url: url, status: 200), Data(authServerJSON.utf8))
+            case "/oauth/token":
+                let proof = request.value(forHTTPHeaderField: "DPoP") ?? ""
+                recorder.record(proof: proof)
+                if recorder.recordedProofs.count == 1 {
+                    return (
+                        jsonResponse(
+                            url: url,
+                            status: 400,
+                            headers: ["DPoP-Nonce": "server-nonce"]
+                        ),
+                        Data(useDPoPNonceJSON.utf8)
+                    )
+                }
+                return (jsonResponse(url: url, status: 200), Data(tokenJSON.utf8))
+            default:
+                return (jsonResponse(url: url, status: 404), Data("{}".utf8))
+            }
+        }
+    }
+
+    @Test(
+        "Token exchange retries once on use_dpop_nonce, with or without a PAR nonce",
+        arguments: [nil, "rotated-par-nonce"] as [String?]
+    )
+    func tokenExchangeRetriesWithServerNonce(initialPARNonce: String?) async throws {
+        let backend = InMemorySecureStorage()
+        let recorder = TokenEndpointRecorder()
+        try await withOAuthFlowTransport(backend, handler: makeHandler(recorder: recorder)) {
+            let namespace = "test.exchange.\(initialPARNonce ?? "no-par-nonce")"
+            let strategy = makeStrategy(namespace: namespace)
+            let storage = KeychainStorage(namespace: namespace)
+            let stateToken = UUID().uuidString
+            let ephemeralKey = P256.Signing.PrivateKey()
+            try await storage.saveOAuthState(
+                OAuthState(
+                    stateToken: stateToken,
+                    codeVerifier: "verifier",
+                    createdAt: Date(),
+                    initialIdentifier: "exchange.example",
+                    targetPDSURL: URL(string: pdsHost)!,
+                    ephemeralDPoPKey: ephemeralKey.rawRepresentation,
+                    parResponseNonce: initialPARNonce,
+                    bskyAppViewDID: nil,
+                    bskyChatDID: nil
+                )
+            )
+
+            let callbackURL = URL(
+                string: "https://client.example/callback?code=auth-code&state=\(stateToken)"
+            )!
+            let result = try await strategy.handleOAuthCallback(url: callbackURL)
+
+            let proofs = recorder.recordedProofs
+            #expect(result.did == "did:plc:parnoncerotation")
+            #expect(proofs.count == 2)
+            let firstNonce = try nonceInProof(#require(proofs.first))
+            let secondNonce = try nonceInProof(#require(proofs.last))
+            #expect(firstNonce == initialPARNonce)
+            #expect(secondNonce == "server-nonce")
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #23. That fix made `updateDPoPNonceInternal` write the JKT-scoped
stores, but the same divergence exists on every other write and clear path, so a
stale nonce can still shadow a fresh one. This makes "write all three stores" and
"clear all three stores" the only shapes in the code.

`OAuthCore.createDPoPProof` resolves a nonce in this order: in-memory
`noncesByThumbprint[jkt][domain]`, persisted `getDPoPNoncesByJKT`, persisted
DID-scoped `getDPoPNonces`. Anything written only to the last layer is invisible.

## What changed

**One helper owns every write.** `writeNonceToAllStores(domain:nonce:did:thumbprint:)`
writes the DID-scoped store, then the in-memory and persisted JKT-scoped stores,
deriving the thumbprint from the DID's DPoP key when the caller doesn't have one.
Both `updateDPoPNonce` and `updateDPoPNonceInternal` go through it.

**`updateDPoPNonce` no longer skips the JKT stores when `jkt` is nil.** The token
endpoint always passes nil (`NetworkService` marks `/oauth/` URLs as not requiring
auth, so no `AuthContext` is built), which meant every successful refresh dropped
the server's fresh nonce into the shadowed DID-scoped store alone — guaranteeing a
wasted `use_dpop_nonce` 400 on the next refresh, forever.

**A failed write is no longer silent.** #23 gated the JKT write on three `try?`s; a
locked keychain skipped it without a word, and the CAB retry then replayed a
guaranteed-stale nonce. Thumbprint derivation failure now logs at error level, and
`updateDPoPNonceInternal` returns `Bool` so both refresh paths skip the retry
instead of burning a request on a nonce the server just rejected.

**Logout and account removal clear everything, scoped to one account.** Both
strategies' `logout()` cleared only `saveDPoPNonces([:])`; they now also clear
`saveDPoPNoncesByJKT([:])` and the in-memory cache. The in-memory clear is
per-account: `clearNonceCache(for:)` uses a DID→thumbprints reverse index, so a
second signed-in account keeps its cached nonces, and it works after the DID's DPoP
key has been deleted (no re-derivation needed). `AccountManager.removeAccount`
cleared no nonce store at all, while its own orphan cleanup cleared both — it now
mirrors that.

**`createDPoPProof` re-merges persistence into memory before reading, at most once
per interval.** Each strategy constructs its own `OAuthCore`, so a stale in-memory
entry could shadow a fresher persisted one; this ports the "persistent wins" merge
the legacy `AuthenticationService` already performs. Doing it on every proof would
add a lookup plus a JSON decode per outbound request, so the merge is rate-limited
to once per 30s per DID (`persistedNonceMergeInterval`). See the trade-off note
below. Since the merge subsumes it, the separate persisted-JKT lookup layer is gone;
the chain is now in-memory (including everything just merged) then DID-scoped.

**A rotated PAR nonce no longer kills login.** Both token exchanges gated the
`use_dpop_nonce` retry on `nonce == nil`, so a PAR nonce that rotated between PAR and
token exchange failed the login outright. The single retry now runs regardless of
whether an initial nonce was supplied.

**`oauthFlowNonces` is live rather than dead, and scoped per flow.** It was read in
`createDPoPProof` but never written, so ephemeral-key proofs always started
nonce-less. It is now keyed by the flow's ephemeral DPoP key thumbprint and then by
host — host alone collides whenever two logins overlap on the same authorization
server, which is the common case when everyone's PDS is bsky.social. Both
`pushAuthorizationRequest` and the token exchange record what the server hands back
(the PAR nonce, the `use_dpop_nonce` challenge, and a successful response's header),
and `handleOAuthCallback` calls `transferOAuthFlowNonces(to:)` right after the flow's
ephemeral key becomes the DID's DPoP key — the same handoff the legacy
`AuthenticationService` does at login. Because the DID's thumbprint at that moment
*is* the flow's ephemeral key, the transfer moves exactly this flow's entries and
leaves a concurrent login's alone. Recording the exchange nonces matters: without it
the callback would hand the new account the nonce the server just rejected.

**A write that fails to persist is not undone by the next merge.** If
`saveDPoPNoncesByJKT` fails (locked keychain) the fresh nonce lives only in memory,
and a later "persistence wins" merge would reinstate the rejected one. Those DIDs are
tracked in `didsWithUnpersistedNonces`, and while flagged a merge may only fill gaps
for them. The flag clears on the next successful persist.

## Staleness window, and what it costs

Within 30s of a merge, an `OAuthCore` signs with the nonce it already holds rather
than re-reading persistence, so it can miss a nonce another `OAuthCore` (or another
process in the keychain access group) wrote during that window. Missing one costs a
single `use_dpop_nonce` 400 whose handler writes the server's fresh nonce to every
store — self-correcting, never a failed request, since that retry is what the DPoP
nonce protocol is for. This instance is the only writer of its own nonces, so
nothing else depends on re-reading sooner.

Worth knowing for anyone weighing the read cost: `KeychainManager` keeps an
`NSCache` in front of the storage backend, so repeated reads of the same key were
already mostly cache hits rather than keychain round trips. The interval still takes
the lookup and JSON decode off the per-request path and, unlike an `NSCache`, cannot
be evicted under memory pressure.

## Tests

`Tests/PetrelTests/Auth/DPoPNonceStoreTests.swift` (12 tests) over the existing
`InMemorySecureStorage` fake: a jkt-nil write reaching all three stores and surviving
into a real proof; an explicit-jkt write; a write reporting failure when the DPoP key
is unreadable; a persisted nonce beating a stale in-memory one; a merge refusing to
clobber a write that failed to persist; the merge interval (a core keeps its cached
nonce inside the window, while a core that has not merged sees the newer value);
logout clearing every store for both strategies; logout leaving a second account's
cache intact; `removeAccount` clearing both persisted stores; the flow-nonce transfer
leaving a concurrent flow alone; and two same-host flows keeping separate nonces.

`Tests/PetrelTests/Auth/OAuthTokenExchangeNonceTests.swift` drives the real
`handleOAuthCallback` path against a stubbed authorization server (both metadata
documents plus a token endpoint that answers `use_dpop_nonce` once) and asserts
exactly two token requests — the first carrying the PAR nonce, the second the
server's — and that the new account's stores end up holding the nonce the server
accepted. Parameterized over "PAR nonce present" and "no PAR nonce", so the rotated
case is covered rather than argued about.

`swift build` and `swift test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTnE6vV45eVCUwQzpMddf6
