### PR TITLE
fix(car,storage): no silent success on corrupt CAR input or failed deletes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ _trash/
 # private key material must never be committed.
 Server/keys/
 *.pem
+.build-xcbeta/

--- a/Sources/Petrel/Core/CAR/CARReader.swift
+++ b/Sources/Petrel/Core/CAR/CARReader.swift
@@ -10,247 +10,251 @@ import SwiftCBOR
 // MARK: - CARReaderError
 
 public enum CARReaderError: LocalizedError {
-  case invalidHeader(String)
-  case invalidVarint
-  case unexpectedEOF
-  case invalidCID(String)
-  case blockNotFound(String)
-  case decodingFailed(String)
+    case invalidHeader(String)
+    case invalidVarint
+    case unexpectedEOF
+    case invalidCID(String)
+    case blockNotFound(String)
+    case decodingFailed(String)
 
-  public var errorDescription: String? {
-    switch self {
-    case .invalidHeader(let msg): return "Invalid CAR header: \(msg)"
-    case .invalidVarint: return "Invalid varint encoding"
-    case .unexpectedEOF: return "Unexpected end of data"
-    case .invalidCID(let msg): return "Invalid CID: \(msg)"
-    case .blockNotFound(let key): return "Block not found for key: \(key)"
-    case .decodingFailed(let msg): return "Decoding failed: \(msg)"
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidHeader(msg): return "Invalid CAR header: \(msg)"
+        case .invalidVarint: return "Invalid varint encoding"
+        case .unexpectedEOF: return "Unexpected end of data"
+        case let .invalidCID(msg): return "Invalid CID: \(msg)"
+        case let .blockNotFound(key): return "Block not found for key: \(key)"
+        case let .decodingFailed(msg): return "Decoding failed: \(msg)"
+        }
     }
-  }
 }
 
 // MARK: - CARReader
 
 public class CARReader {
+    // MARK: - Types
 
-  // MARK: - Types
+    public struct BlockLocation {
+        public let dataOffset: Int
+        public let dataLength: Int
+    }
 
-  public struct BlockLocation {
-    public let dataOffset: Int
-    public let dataLength: Int
-  }
+    // MARK: - Properties
 
-  // MARK: - Properties
+    private let data: Data
+    private var offset: Int = 0
 
-  private let data: Data
-  private var offset: Int = 0
+    /// Maps CID hex string → block location in the data
+    public private(set) var blockIndex: [String: BlockLocation] = [:]
 
-  /// Maps CID hex string → block location in the data
-  public private(set) var blockIndex: [String: BlockLocation] = [:]
+    /// CID roots from the CAR header
+    public private(set) var roots: [CID] = []
 
-  /// CID roots from the CAR header
-  public private(set) var roots: [CID] = []
+    // MARK: - Init
 
-  // MARK: - Init
+    public init(data: Data) throws {
+        self.data = data
+        try parseHeader()
+        try indexBlocks()
+    }
 
-  public init(data: Data) throws {
-    self.data = data
-    try parseHeader()
-    try indexBlocks()
-  }
+    public convenience init(fileURL: URL) throws {
+        let data = try Data(contentsOf: fileURL)
+        try self.init(data: data)
+    }
 
-  public convenience init(fileURL: URL) throws {
-    let data = try Data(contentsOf: fileURL)
-    try self.init(data: data)
-  }
+    // MARK: - Varint
 
-  // MARK: - Varint
+    /// Reads an unsigned LEB128 varint from the current offset.
+    @discardableResult
+    public func readVarint() throws -> Int {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
 
-  /// Reads an unsigned LEB128 varint from the current offset.
-  @discardableResult
-  public func readVarint() throws -> Int {
-    var result: UInt64 = 0
-    var shift: UInt64 = 0
+        while offset < data.count {
+            let byte = data[offset]
+            offset += 1
 
-    while offset < data.count {
-      let byte = data[offset]
-      offset += 1
+            result |= UInt64(byte & 0x7F) << shift
 
-      result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 {
+                guard result <= UInt64(Int.max) else {
+                    throw CARReaderError.invalidVarint
+                }
+                return Int(result)
+            }
 
-      if byte & 0x80 == 0 {
-        guard result <= UInt64(Int.max) else {
-          throw CARReaderError.invalidVarint
+            shift += 7
+            if shift > 63 {
+                throw CARReaderError.invalidVarint
+            }
         }
-        return Int(result)
-      }
 
-      shift += 7
-      if shift > 63 {
-        throw CARReaderError.invalidVarint
-      }
+        throw CARReaderError.unexpectedEOF
     }
 
-    throw CARReaderError.unexpectedEOF
-  }
+    // MARK: - Header
 
-  // MARK: - Header
+    private func parseHeader() throws {
+        let headerLength = try readVarint()
 
-  private func parseHeader() throws {
-    let headerLength = try readVarint()
-
-    guard offset + headerLength <= data.count else {
-      throw CARReaderError.unexpectedEOF
-    }
-
-    let headerData = data[offset..<(offset + headerLength)]
-    offset += headerLength
-
-    guard let cbor = try? CBOR.decode([UInt8](headerData)) else {
-      throw CARReaderError.invalidHeader("Failed to decode CBOR header")
-    }
-
-    guard case .map(let map) = cbor else {
-      throw CARReaderError.invalidHeader("Header is not a CBOR map")
-    }
-
-    // Check version
-    if let versionCBOR = map[.utf8String("version")] {
-      switch versionCBOR {
-      case .unsignedInt(let v):
-        guard v == 1 else {
-          throw CARReaderError.invalidHeader("Unsupported CAR version: \(v)")
+        guard offset + headerLength <= data.count else {
+            throw CARReaderError.unexpectedEOF
         }
-      default:
-        throw CARReaderError.invalidHeader("Invalid version field type")
-      }
-    }
 
-    // Parse roots
-    if let rootsCBOR = map[.utf8String("roots")] {
-      guard case .array(let rootArray) = rootsCBOR else {
-        throw CARReaderError.invalidHeader("Roots is not an array")
-      }
+        let headerData = data[offset ..< (offset + headerLength)]
+        offset += headerLength
 
-      for rootItem in rootArray {
-        if case .tagged(let tag, let value) = rootItem, tag.rawValue == 42 {
-          // Tag 42 CID link
-          if case .byteString(let bytes) = value, bytes.count > 1, bytes[0] == 0x00 {
-            let cidBytes = Data(bytes.dropFirst())
-            let cid = try CID(bytes: cidBytes)
-            roots.append(cid)
-          }
-        } else if case .byteString(let bytes) = rootItem {
-          // Raw CID bytes
-          let cid = try CID(bytes: Data(bytes))
-          roots.append(cid)
+        guard let cbor = try? CBOR.decode([UInt8](headerData)) else {
+            throw CARReaderError.invalidHeader("Failed to decode CBOR header")
         }
-      }
-    }
-  }
 
-  // MARK: - Block Indexing
+        guard case let .map(map) = cbor else {
+            throw CARReaderError.invalidHeader("Header is not a CBOR map")
+        }
 
-  private func indexBlocks() throws {
-    while offset < data.count {
-      let totalLength: Int
-      do {
-        totalLength = try readVarint()
-      } catch {
-        // End of data during varint read — done
-        break
-      }
+        // Check version
+        if let versionCBOR = map[.utf8String("version")] {
+            switch versionCBOR {
+            case let .unsignedInt(v):
+                guard v == 1 else {
+                    throw CARReaderError.invalidHeader("Unsupported CAR version: \(v)")
+                }
+            default:
+                throw CARReaderError.invalidHeader("Invalid version field type")
+            }
+        }
 
-      guard totalLength > 0, offset + totalLength <= data.count else {
-        break
-      }
+        // Parse roots
+        if let rootsCBOR = map[.utf8String("roots")] {
+            guard case let .array(rootArray) = rootsCBOR else {
+                throw CARReaderError.invalidHeader("Roots is not an array")
+            }
 
-      let blockDataStart = offset
-
-      // Parse CID from block: version + codec + multihash(algo + length + digest)
-      let cidStart = offset
-
-      guard offset < data.count else { break }
-      let version = data[offset]
-      offset += 1
-
-      if version == 0x12 {
-        // CIDv0 (starts with sha2-256 multihash directly) — rare but handle it
-        // sha2-256: code=0x12, length=0x20, then 32 bytes digest
-        guard offset < data.count else { break }
-        let hashLen = data[offset]
-        offset += 1
-        let digestLen = Int(hashLen)
-        guard offset + digestLen <= blockDataStart + totalLength else { break }
-        offset += digestLen
-
-        let cidData = data[cidStart..<offset]
-        let cidHex = cidData.map { String(format: "%02x", $0) }.joined()
-
-        let dataOffset = offset
-        let dataLength = totalLength - (offset - blockDataStart)
-        blockIndex[cidHex] = BlockLocation(dataOffset: dataOffset, dataLength: dataLength)
-        offset = blockDataStart + totalLength
-        continue
-      }
-
-      // CIDv1
-      guard offset < data.count else { break }
-      // Skip the one-byte codec. The full CID bytes are retained below.
-      offset += 1
-
-      // Multihash: algorithm + length + digest
-      guard offset < data.count else { break }
-      // Skip the one-byte hash algorithm. The full CID bytes are retained below.
-      offset += 1
-
-      guard offset < data.count else { break }
-      let hashLen = data[offset]
-      offset += 1
-
-      let digestLen = Int(hashLen)
-      guard offset + digestLen <= blockDataStart + totalLength else { break }
-      offset += digestLen
-
-      let cidData = data[cidStart..<offset]
-      let cidHex = cidData.map { String(format: "%02x", $0) }.joined()
-
-      let dataOffset = offset
-      let dataLength = totalLength - (offset - blockDataStart)
-
-      blockIndex[cidHex] = BlockLocation(dataOffset: dataOffset, dataLength: dataLength)
-
-      offset = blockDataStart + totalLength
-    }
-  }
-
-  // MARK: - Block Access
-
-  /// Retrieves and decodes the CBOR block for a given CID hex key.
-  public func decodeBlock(for key: String) throws -> Any? {
-    guard let location = blockIndex[key] else {
-      throw CARReaderError.blockNotFound(key)
+            for rootItem in rootArray {
+                if case let .tagged(tag, value) = rootItem, tag.rawValue == 42 {
+                    // Tag 42 CID link
+                    if case let .byteString(bytes) = value, bytes.count > 1, bytes[0] == 0x00 {
+                        let cidBytes = Data(bytes.dropFirst())
+                        let cid = try CID(bytes: cidBytes)
+                        roots.append(cid)
+                    }
+                } else if case let .byteString(bytes) = rootItem {
+                    // Raw CID bytes
+                    let cid = try CID(bytes: Data(bytes))
+                    roots.append(cid)
+                }
+            }
+        }
     }
 
-    let blockData = data[location.dataOffset..<(location.dataOffset + location.dataLength)]
+    // MARK: - Block Indexing
 
-    guard let cbor = try? CBOR.decode([UInt8](blockData)) else {
-      throw CARReaderError.decodingFailed("Failed to decode CBOR for block \(key)")
+    /// Indexes every block in the CAR body.
+    ///
+    /// The only clean end of the archive is a block that ends exactly on `data.count`;
+    /// the loop condition detects it. Every other framing violation — a truncated length
+    /// prefix, a length that runs past the end, a CID that does not fit inside its own
+    /// block — is corruption and throws, so a truncated archive can never be indexed as a
+    /// smaller but seemingly intact one.
+    private func indexBlocks() throws {
+        while offset < data.count {
+            let totalLength = try readVarint()
+
+            guard totalLength > 0 else {
+                throw CARReaderError.invalidVarint
+            }
+            guard offset + totalLength <= data.count else {
+                throw CARReaderError.unexpectedEOF
+            }
+
+            let blockDataStart = offset
+            let blockEnd = blockDataStart + totalLength
+
+            // Parse CID from block: version + codec + multihash(algo + length + digest)
+            let cidStart = offset
+
+            guard offset < blockEnd else { throw CARReaderError.unexpectedEOF }
+            let version = data[offset]
+            offset += 1
+
+            if version == 0x12 {
+                // CIDv0 (starts with sha2-256 multihash directly) — rare but handle it
+                // sha2-256: code=0x12, length=0x20, then 32 bytes digest
+                guard offset < blockEnd else { throw CARReaderError.unexpectedEOF }
+                let hashLen = data[offset]
+                offset += 1
+                let digestLen = Int(hashLen)
+                guard offset + digestLen <= blockEnd else { throw CARReaderError.unexpectedEOF }
+                offset += digestLen
+
+                let cidData = data[cidStart ..< offset]
+                let cidHex = cidData.map { String(format: "%02x", $0) }.joined()
+
+                let dataOffset = offset
+                let dataLength = totalLength - (offset - blockDataStart)
+                blockIndex[cidHex] = BlockLocation(dataOffset: dataOffset, dataLength: dataLength)
+                offset = blockEnd
+                continue
+            }
+
+            // CIDv1
+            guard offset < blockEnd else { throw CARReaderError.unexpectedEOF }
+            // Skip the one-byte codec. The full CID bytes are retained below.
+            offset += 1
+
+            // Multihash: algorithm + length + digest
+            guard offset < blockEnd else { throw CARReaderError.unexpectedEOF }
+            // Skip the one-byte hash algorithm. The full CID bytes are retained below.
+            offset += 1
+
+            guard offset < blockEnd else { throw CARReaderError.unexpectedEOF }
+            let hashLen = data[offset]
+            offset += 1
+
+            let digestLen = Int(hashLen)
+            guard offset + digestLen <= blockEnd else { throw CARReaderError.unexpectedEOF }
+            offset += digestLen
+
+            let cidData = data[cidStart ..< offset]
+            let cidHex = cidData.map { String(format: "%02x", $0) }.joined()
+
+            let dataOffset = offset
+            let dataLength = totalLength - (offset - blockDataStart)
+
+            blockIndex[cidHex] = BlockLocation(dataOffset: dataOffset, dataLength: dataLength)
+
+            offset = blockEnd
+        }
     }
 
-    return try DAGCBOR.decodeCBORItem(cbor)
-  }
+    // MARK: - Block Access
 
-  /// Returns raw block data for a given CID hex key.
-  public func rawBlockData(for key: String) throws -> Data {
-    guard let location = blockIndex[key] else {
-      throw CARReaderError.blockNotFound(key)
+    /// Retrieves and decodes the CBOR block for a given CID hex key.
+    public func decodeBlock(for key: String) throws -> Any? {
+        guard let location = blockIndex[key] else {
+            throw CARReaderError.blockNotFound(key)
+        }
+
+        let blockData = data[location.dataOffset ..< (location.dataOffset + location.dataLength)]
+
+        guard let cbor = try? CBOR.decode([UInt8](blockData)) else {
+            throw CARReaderError.decodingFailed("Failed to decode CBOR for block \(key)")
+        }
+
+        return try DAGCBOR.decodeCBORItem(cbor)
     }
-    return Data(data[location.dataOffset..<(location.dataOffset + location.dataLength)])
-  }
 
-  /// Returns the CID hex string for a CID struct by encoding its bytes.
-  public static func cidHex(from cid: CID) -> String {
-    cid.bytes.map { String(format: "%02x", $0) }.joined()
-  }
+    /// Returns raw block data for a given CID hex key.
+    public func rawBlockData(for key: String) throws -> Data {
+        guard let location = blockIndex[key] else {
+            throw CARReaderError.blockNotFound(key)
+        }
+        return Data(data[location.dataOffset ..< (location.dataOffset + location.dataLength)])
+    }
+
+    /// Returns the CID hex string for a CID struct by encoding its bytes.
+    public static func cidHex(from cid: CID) -> String {
+        cid.bytes.map { String(format: "%02x", $0) }.joined()
+    }
 }

--- a/Sources/Petrel/Core/CAR/CARRepository.swift
+++ b/Sources/Petrel/Core/CAR/CARRepository.swift
@@ -11,278 +11,287 @@ import SwiftCBOR
 // MARK: - CARRepository
 
 public enum CARRepository {
+    // MARK: - Types
 
-  // MARK: - Types
-
-  public struct Record {
-    public let collection: String
-    public let rkey: String
-    public let cid: CID
-    public let value: ATProtocolValueContainer
-    public let rawCBOR: Data
-  }
-
-  public struct Stats {
-    public let blockCount: Int
-    public let recordCount: Int
-    public let decodedCount: Int
-    public let failedCount: Int
-    public let roots: [CID]
-  }
-
-  /// Recursively decodes the JSON emitted by `DAGCBORJSONBridge` without
-  /// requiring every value to be an object. Exact DAG-JSON link and bytes
-  /// objects recover their semantic container cases so DAG-CBOR re-encoding
-  /// retains Tag 42 and byte-string wire forms.
-  private struct CARJSONValue: Decodable {
-    let value: ATProtocolValueContainer
-
-    init(from decoder: Decoder) throws {
-      if let primitive = try Self.decodePrimitive(from: decoder) {
-        value = primitive
-        return
-      }
-      if let array = try Self.decodeArray(from: decoder) {
-        value = .array(array)
-        return
-      }
-
-      let objectContainer = try decoder.container(keyedBy: CARJSONCodingKey.self)
-      value = try Self.decodeObjectValue(from: objectContainer, decoder: decoder)
+    public struct Record {
+        public let collection: String
+        public let rkey: String
+        public let cid: CID
+        public let value: ATProtocolValueContainer
+        public let rawCBOR: Data
     }
 
-    private static func decodePrimitive(
-      from decoder: Decoder
-    ) throws -> ATProtocolValueContainer? {
-      let singleValue = try decoder.singleValueContainer()
-
-      if singleValue.decodeNil() {
-        return .null
-      }
-      if let boolValue = try? singleValue.decode(Bool.self) {
-        return .bool(boolValue)
-      }
-      if let intValue = try? singleValue.decode(Int.self) {
-        return .number(intValue)
-      }
-      if let stringValue = try? singleValue.decode(String.self) {
-        // CAR's bridge policy intentionally represents unsigned integers above
-        // Int.max as decimal strings, so preserve all JSON strings verbatim.
-        return .string(stringValue)
-      }
-      return nil
+    public struct Stats {
+        public let blockCount: Int
+        public let recordCount: Int
+        public let decodedCount: Int
+        /// Records that decoded but matched no generated Lexicon type, so they were
+        /// preserved as `.unknownType`. They are counted in `decodedCount` as well;
+        /// a non-zero value here means schema drift, not a clean decode.
+        public let downgradedCount: Int
+        public let failedCount: Int
+        public let roots: [CID]
     }
 
-    private static func decodeArray(
-      from decoder: Decoder
-    ) throws -> [ATProtocolValueContainer]? {
-      guard var arrayContainer = try? decoder.unkeyedContainer() else {
-        return nil
-      }
+    /// Recursively decodes the JSON emitted by `DAGCBORJSONBridge` without
+    /// requiring every value to be an object. Exact DAG-JSON link and bytes
+    /// objects recover their semantic container cases so DAG-CBOR re-encoding
+    /// retains Tag 42 and byte-string wire forms.
+    private struct CARJSONValue: Decodable {
+        let value: ATProtocolValueContainer
 
-      var array = [ATProtocolValueContainer]()
-      while !arrayContainer.isAtEnd {
-        if try arrayContainer.decodeNil() {
-          array.append(.null)
-        } else {
-          try array.append(arrayContainer.decode(CARJSONValue.self).value)
-        }
-      }
-      return array
-    }
-
-    private static func decodeObjectValue(
-      from container: KeyedDecodingContainer<CARJSONCodingKey>,
-      decoder: Decoder
-    ) throws -> ATProtocolValueContainer {
-      if let specialObject = try decodeSpecialObject(from: container) {
-        return specialObject
-      }
-
-      if let typeKey = container.allKeys.first(where: { $0.stringValue == "$type" }) {
-        if let typeValue = try? container.decode(String.self, forKey: typeKey) {
-          if let typedValue = try? ATProtocolValueContainer(from: decoder) {
-            if case .unknownType = typedValue {
-              return try decodeUnknownType(typeValue, from: container)
+        init(from decoder: Decoder) throws {
+            if let primitive = try Self.decodePrimitive(from: decoder) {
+                value = primitive
+                return
             }
-            return typedValue
-          }
-          return try decodeUnknownType(typeValue, from: container)
+            if let array = try Self.decodeArray(from: decoder) {
+                value = .array(array)
+                return
+            }
+
+            let objectContainer = try decoder.container(keyedBy: CARJSONCodingKey.self)
+            value = try Self.decodeObjectValue(from: objectContainer, decoder: decoder)
         }
-      }
 
-      return try .object(decodeObject(from: container))
-    }
+        private static func decodePrimitive(
+            from decoder: Decoder
+        ) throws -> ATProtocolValueContainer? {
+            let singleValue = try decoder.singleValueContainer()
 
-    private static func decodeUnknownType(
-      _ typeValue: String,
-      from container: KeyedDecodingContainer<CARJSONCodingKey>
-    ) throws -> ATProtocolValueContainer {
-      return try .unknownType(
-        typeValue,
-        .object(decodeObject(from: container))
-      )
-    }
-
-    private static func decodeSpecialObject(
-      from container: KeyedDecodingContainer<CARJSONCodingKey>
-    ) throws -> ATProtocolValueContainer? {
-      guard container.allKeys.count == 1, let onlyKey = container.allKeys.first else {
-        return nil
-      }
-
-      switch onlyKey.stringValue {
-      case "$link":
-        let cidString = try container.decode(String.self, forKey: onlyKey)
-        return try .link(ATProtoLink(cidString: cidString))
-      case "$bytes":
-        let base64String = try container.decode(String.self, forKey: onlyKey)
-        guard let data = Data(base64Encoded: base64String) else {
-          throw DecodingError.dataCorruptedError(
-            forKey: onlyKey,
-            in: container,
-            debugDescription: "Invalid base64 in exact $bytes object"
-          )
+            if singleValue.decodeNil() {
+                return .null
+            }
+            if let boolValue = try? singleValue.decode(Bool.self) {
+                return .bool(boolValue)
+            }
+            if let intValue = try? singleValue.decode(Int.self) {
+                return .number(intValue)
+            }
+            if let stringValue = try? singleValue.decode(String.self) {
+                // CAR's bridge policy intentionally represents unsigned integers above
+                // Int.max as decimal strings, so preserve all JSON strings verbatim.
+                return .string(stringValue)
+            }
+            return nil
         }
-        return .bytes(Bytes(data: data))
-      default:
-        return nil
-      }
-    }
 
-    private static func decodeObject(
-      from container: KeyedDecodingContainer<CARJSONCodingKey>
-    ) throws -> [String: ATProtocolValueContainer] {
-      var object = [String: ATProtocolValueContainer]()
-      for key in container.allKeys {
-        if try container.decodeNil(forKey: key) {
-          object[key.stringValue] = .null
-        } else {
-          object[key.stringValue] = try container.decode(CARJSONValue.self, forKey: key).value
+        private static func decodeArray(
+            from decoder: Decoder
+        ) throws -> [ATProtocolValueContainer]? {
+            guard var arrayContainer = try? decoder.unkeyedContainer() else {
+                return nil
+            }
+
+            var array = [ATProtocolValueContainer]()
+            while !arrayContainer.isAtEnd {
+                if try arrayContainer.decodeNil() {
+                    array.append(.null)
+                } else {
+                    try array.append(arrayContainer.decode(CARJSONValue.self).value)
+                }
+            }
+            return array
         }
-      }
-      return object
+
+        private static func decodeObjectValue(
+            from container: KeyedDecodingContainer<CARJSONCodingKey>,
+            decoder: Decoder
+        ) throws -> ATProtocolValueContainer {
+            if let specialObject = try decodeSpecialObject(from: container) {
+                return specialObject
+            }
+
+            if let typeKey = container.allKeys.first(where: { $0.stringValue == "$type" }) {
+                if let typeValue = try? container.decode(String.self, forKey: typeKey) {
+                    if let typedValue = try? ATProtocolValueContainer(from: decoder) {
+                        if case .unknownType = typedValue {
+                            return try decodeUnknownType(typeValue, from: container)
+                        }
+                        return typedValue
+                    }
+                    return try decodeUnknownType(typeValue, from: container)
+                }
+            }
+
+            return try .object(decodeObject(from: container))
+        }
+
+        private static func decodeUnknownType(
+            _ typeValue: String,
+            from container: KeyedDecodingContainer<CARJSONCodingKey>
+        ) throws -> ATProtocolValueContainer {
+            return try .unknownType(
+                typeValue,
+                .object(decodeObject(from: container))
+            )
+        }
+
+        private static func decodeSpecialObject(
+            from container: KeyedDecodingContainer<CARJSONCodingKey>
+        ) throws -> ATProtocolValueContainer? {
+            guard container.allKeys.count == 1, let onlyKey = container.allKeys.first else {
+                return nil
+            }
+
+            switch onlyKey.stringValue {
+            case "$link":
+                let cidString = try container.decode(String.self, forKey: onlyKey)
+                return try .link(ATProtoLink(cidString: cidString))
+            case "$bytes":
+                let base64String = try container.decode(String.self, forKey: onlyKey)
+                guard let data = Data(base64Encoded: base64String) else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: onlyKey,
+                        in: container,
+                        debugDescription: "Invalid base64 in exact $bytes object"
+                    )
+                }
+                return .bytes(Bytes(data: data))
+            default:
+                return nil
+            }
+        }
+
+        private static func decodeObject(
+            from container: KeyedDecodingContainer<CARJSONCodingKey>
+        ) throws -> [String: ATProtocolValueContainer] {
+            var object = [String: ATProtocolValueContainer]()
+            for key in container.allKeys {
+                if try container.decodeNil(forKey: key) {
+                    object[key.stringValue] = .null
+                } else {
+                    object[key.stringValue] = try container.decode(CARJSONValue.self, forKey: key).value
+                }
+            }
+            return object
+        }
     }
-  }
 
-  private struct CARJSONCodingKey: CodingKey {
-    let stringValue: String
-    let intValue: Int?
+    private struct CARJSONCodingKey: CodingKey {
+        let stringValue: String
+        let intValue: Int?
 
-    init?(stringValue: String) {
-      self.stringValue = stringValue
-      intValue = nil
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            intValue = nil
+        }
+
+        init?(intValue: Int) {
+            stringValue = String(intValue)
+            self.intValue = intValue
+        }
     }
 
-    init?(intValue: Int) {
-      stringValue = String(intValue)
-      self.intValue = intValue
+    // MARK: - Parsing
+
+    /// Parses a CAR file, walking the MST and decoding each record.
+    ///
+    /// - Parameters:
+    ///   - fileURL: Path to the `.car` file.
+    ///   - onRecord: Called for each decoded record.
+    /// - Returns: Aggregate statistics about the parse.
+    public static func parse(
+        fileURL: URL,
+        onRecord: (Record) throws -> Void
+    ) throws -> Stats {
+        let reader = try CARReader(fileURL: fileURL)
+
+        let traverser = MSTTraverser(reader: reader)
+        var recordCount = 0
+        var decodedCount = 0
+        var downgradedCount = 0
+        var failedCount = 0
+
+        guard let commitRoot = reader.roots.first else {
+            return Stats(
+                blockCount: reader.blockIndex.count,
+                recordCount: 0,
+                decodedCount: 0,
+                downgradedCount: 0,
+                failedCount: 0,
+                roots: reader.roots
+            )
+        }
+
+        try traverser.walkRepository(commitCID: commitRoot) { path, recordCID in
+            recordCount += 1
+
+            // Split "collection/rkey" path
+            let parts = path.split(separator: "/", maxSplits: 1)
+            let collection = parts.count > 0 ? String(parts[0]) : ""
+            let rkey = parts.count > 1 ? String(parts[1]) : ""
+
+            let cidHex = CARReader.cidHex(from: recordCID)
+
+            do {
+                let rawData = try reader.rawBlockData(for: cidHex)
+                let value = try decodeRecordCBOR(rawData)
+
+                let record = Record(
+                    collection: collection,
+                    rkey: rkey,
+                    cid: recordCID,
+                    value: value,
+                    rawCBOR: rawData
+                )
+
+                decodedCount += 1
+                if case .unknownType = value {
+                    downgradedCount += 1
+                }
+                try onRecord(record)
+            } catch {
+                failedCount += 1
+
+                // Still emit the record with a decode error
+                let errorRecord = Record(
+                    collection: collection,
+                    rkey: rkey,
+                    cid: recordCID,
+                    value: .decodeError("Failed to decode: \(error.localizedDescription)"),
+                    rawCBOR: Data()
+                )
+                try onRecord(errorRecord)
+            }
+        }
+
+        return Stats(
+            blockCount: reader.blockIndex.count,
+            recordCount: recordCount,
+            decodedCount: decodedCount,
+            downgradedCount: downgradedCount,
+            failedCount: failedCount,
+            roots: reader.roots
+        )
     }
-  }
 
-  // MARK: - Parsing
+    // MARK: - CBOR Decoding
 
-  /// Parses a CAR file, walking the MST and decoding each record.
-  ///
-  /// - Parameters:
-  ///   - fileURL: Path to the `.car` file.
-  ///   - onRecord: Called for each decoded record.
-  /// - Returns: Aggregate statistics about the parse.
-  public static func parse(
-    fileURL: URL,
-    onRecord: (Record) throws -> Void
-  ) throws -> Stats {
-    let reader = try CARReader(fileURL: fileURL)
+    /// Decodes raw DAG-CBOR data into an `ATProtocolValueContainer`.
+    ///
+    /// Flow: CBOR bytes → SwiftCBOR parse → DAGCBOR.decodeCBORItem → Swift dict → JSON → ATProtocolValueContainer
+    public static func decodeRecordCBOR(_ data: Data) throws -> ATProtocolValueContainer {
+        guard !data.isEmpty else {
+            throw CARReaderError.decodingFailed("Empty CBOR data")
+        }
 
-    let traverser = MSTTraverser(reader: reader)
-    var recordCount = 0
-    var decodedCount = 0
-    var failedCount = 0
+        guard let cborItem = try? CBOR.decode([UInt8](data)) else {
+            throw CARReaderError.decodingFailed("Failed to parse CBOR")
+        }
 
-    guard let commitRoot = reader.roots.first else {
-      return Stats(
-        blockCount: reader.blockIndex.count,
-        recordCount: 0,
-        decodedCount: 0,
-        failedCount: 0,
-        roots: reader.roots
-      )
-    }
+        let intermediate = try DAGCBOR.decodeCBORItem(cborItem)
 
-    try traverser.walkRepository(commitCID: commitRoot) { path, recordCID in
-      recordCount += 1
+        let isMapRoot = intermediate is [String: Any]
+        guard isMapRoot || intermediate is [Any] else {
+            throw CARReaderError.decodingFailed("CBOR root is not a map or array")
+        }
 
-      // Split "collection/rkey" path
-      let parts = path.split(separator: "/", maxSplits: 1)
-      let collection = parts.count > 0 ? String(parts[0]) : ""
-      let rkey = parts.count > 1 ? String(parts[1]) : ""
-
-      let cidHex = CARReader.cidHex(from: recordCID)
-
-      do {
-        let rawData = try reader.rawBlockData(for: cidHex)
-        let value = try decodeRecordCBOR(rawData)
-
-        let record = Record(
-          collection: collection,
-          rkey: rkey,
-          cid: recordCID,
-          value: value,
-          rawCBOR: rawData
+        let jsonData = try DAGCBORJSONBridge.jsonData(
+            from: intermediate,
+            unsignedIntegerPolicy: .stringifyAboveIntMax
         )
 
-        decodedCount += 1
-        try onRecord(record)
-      } catch {
-        failedCount += 1
-
-        // Still emit the record with a decode error
-        let errorRecord = Record(
-          collection: collection,
-          rkey: rkey,
-          cid: recordCID,
-          value: .decodeError("Failed to decode: \(error.localizedDescription)"),
-          rawCBOR: Data()
-        )
-        try onRecord(errorRecord)
-      }
+        return try JSONDecoder().decode(CARJSONValue.self, from: jsonData).value
     }
-
-    return Stats(
-      blockCount: reader.blockIndex.count,
-      recordCount: recordCount,
-      decodedCount: decodedCount,
-      failedCount: failedCount,
-      roots: reader.roots
-    )
-  }
-
-  // MARK: - CBOR Decoding
-
-  /// Decodes raw DAG-CBOR data into an `ATProtocolValueContainer`.
-  ///
-  /// Flow: CBOR bytes → SwiftCBOR parse → DAGCBOR.decodeCBORItem → Swift dict → JSON → ATProtocolValueContainer
-  public static func decodeRecordCBOR(_ data: Data) throws -> ATProtocolValueContainer {
-    guard !data.isEmpty else {
-      throw CARReaderError.decodingFailed("Empty CBOR data")
-    }
-
-    guard let cborItem = try? CBOR.decode([UInt8](data)) else {
-      throw CARReaderError.decodingFailed("Failed to parse CBOR")
-    }
-
-    let intermediate = try DAGCBOR.decodeCBORItem(cborItem)
-
-    let isMapRoot = intermediate is [String: Any]
-    guard isMapRoot || intermediate is [Any] else {
-      throw CARReaderError.decodingFailed("CBOR root is not a map or array")
-    }
-
-    let jsonData = try DAGCBORJSONBridge.jsonData(
-      from: intermediate,
-      unsignedIntegerPolicy: .stringifyAboveIntMax
-    )
-
-    return try JSONDecoder().decode(CARJSONValue.self, from: jsonData).value
-  }
 }

--- a/Sources/Petrel/Core/CAR/MSTTraverser.swift
+++ b/Sources/Petrel/Core/CAR/MSTTraverser.swift
@@ -9,93 +9,152 @@ import Foundation
 // MARK: - MSTTraverser
 
 public class MSTTraverser {
+    private let reader: CARReader
 
-  private let reader: CARReader
-
-  public init(reader: CARReader) {
-    self.reader = reader
-  }
-
-  /// Walks the repository starting from a commit CID, calling `onRecord` for each leaf record.
-  ///
-  /// The commit node contains a `data` field pointing to the MST root.
-  /// MST nodes have `l` (left subtree), `e` (entries array) where each entry has
-  /// `k` (key suffix bytes), `p` (prefix count), `v` (value CID), and `t` (right subtree).
-  public func walkRepository(commitCID: CID, onRecord: (String, CID) throws -> Void) throws {
-    let commitHex = CARReader.cidHex(from: commitCID)
-
-    guard let commitNode = try reader.decodeBlock(for: commitHex) as? [String: Any] else {
-      throw CARReaderError.decodingFailed("Failed to decode commit node")
+    public init(reader: CARReader) {
+        self.reader = reader
     }
 
-    // The commit node's "data" field is the MST root CID
-    guard let dataCID = commitNode["data"] as? CID else {
-      throw CARReaderError.decodingFailed("Commit node missing 'data' CID")
+    /// Walks the repository starting from a commit CID, calling `onRecord` for each leaf record.
+    ///
+    /// The commit node contains a `data` field pointing to the MST root.
+    /// MST nodes have `l` (left subtree), `e` (entries array) where each entry has
+    /// `k` (key suffix bytes), `p` (prefix count), `v` (value CID), and `t` (right subtree).
+    ///
+    /// Every field the spec marks required is required here, and a malformed node throws
+    /// instead of being skipped: skipping a node also skips each of its right subtrees, and
+    /// keys are prefix-compressed against the previous entry, so one bad entry corrupts every
+    /// key after it in the node.
+    public func walkRepository(commitCID: CID, onRecord: (String, CID) throws -> Void) throws {
+        let commitHex = CARReader.cidHex(from: commitCID)
+
+        guard let commitNode = try reader.decodeBlock(for: commitHex) as? [String: Any] else {
+            throw CARReaderError.decodingFailed("Failed to decode commit node")
+        }
+
+        // The commit node's "data" field is the MST root CID
+        guard let dataCID = commitNode["data"] as? CID else {
+            throw CARReaderError.decodingFailed("Commit node missing 'data' CID")
+        }
+
+        try walkMSTNode(cid: dataCID, prefix: "", onRecord: onRecord)
     }
 
-    try walkMSTNode(cid: dataCID, prefix: "", onRecord: onRecord)
-  }
+    // MARK: - MST Node Walking
 
-  // MARK: - MST Node Walking
+    private func walkMSTNode(
+        cid: CID,
+        prefix: String,
+        onRecord: (String, CID) throws -> Void
+    ) throws {
+        let nodeHex = CARReader.cidHex(from: cid)
 
-  private func walkMSTNode(
-    cid: CID,
-    prefix: String,
-    onRecord: (String, CID) throws -> Void
-  ) throws {
-    let nodeHex = CARReader.cidHex(from: cid)
+        guard let node = try reader.decodeBlock(for: nodeHex) as? [String: Any] else {
+            throw CARReaderError.decodingFailed("Failed to decode MST node \(nodeHex)")
+        }
 
-    guard let node = try reader.decodeBlock(for: nodeHex) as? [String: Any] else {
-      throw CARReaderError.decodingFailed("Failed to decode MST node \(nodeHex)")
+        // "l" — optional left subtree CID
+        if let leftCID = node["l"] as? CID {
+            try walkMSTNode(cid: leftCID, prefix: prefix, onRecord: onRecord)
+        }
+
+        // "e" — entries array. Required; a node with no entries serializes as an empty array.
+        guard let entries = node["e"] as? [Any] else {
+            throw CARReaderError.decodingFailed(
+                "MST node \(nodeHex) is missing its required 'e' entries array"
+            )
+        }
+
+        var lastKey = prefix
+
+        for (index, rawEntry) in entries.enumerated() {
+            guard let entry = rawEntry as? [String: Any] else {
+                throw CARReaderError.decodingFailed("MST node \(nodeHex) entry \(index) is not a map")
+            }
+
+            // "p" — how many characters of the previous key to keep as prefix
+            let prefixCount = try entryPrefixCount(entry, nodeHex: nodeHex, index: index)
+            guard prefixCount <= lastKey.count else {
+                throw CARReaderError.decodingFailed(
+                    "MST node \(nodeHex) entry \(index) prefix count \(prefixCount) exceeds previous key length \(lastKey.count)"
+                )
+            }
+
+            // "k" — key suffix as bytes
+            let keySuffix = try entryKeySuffix(entry, nodeHex: nodeHex, index: index)
+
+            // Build full key: take `prefixCount` chars from previous key + suffix
+            let prefixPart = String(lastKey.prefix(prefixCount))
+            let fullKey = prefixPart + keySuffix
+            lastKey = fullKey
+
+            // "v" — value CID (the record)
+            guard let valueCID = entry["v"] as? CID else {
+                throw CARReaderError.decodingFailed(
+                    "MST node \(nodeHex) entry \(index) is missing its required 'v' value CID"
+                )
+            }
+            try onRecord(fullKey, valueCID)
+
+            // "t" — optional right subtree
+            if let treeCID = entry["t"] as? CID {
+                try walkMSTNode(cid: treeCID, prefix: prefix, onRecord: onRecord)
+            }
+        }
     }
 
-    // "l" — optional left subtree CID
-    if let leftCID = node["l"] as? CID {
-      try walkMSTNode(cid: leftCID, prefix: prefix, onRecord: onRecord)
+    // MARK: - Entry Fields
+
+    /// DAG-CBOR unsigned integers decode as `UInt64`; the `Int` branch tolerates an
+    /// intermediate that already narrowed the value.
+    private func entryPrefixCount(
+        _ entry: [String: Any],
+        nodeHex: String,
+        index: Int
+    ) throws -> Int {
+        if let p = entry["p"] as? UInt64 {
+            guard p <= UInt64(Int.max) else {
+                throw CARReaderError.decodingFailed(
+                    "MST node \(nodeHex) entry \(index) prefix count \(p) is out of range"
+                )
+            }
+            return Int(p)
+        }
+
+        if let p = entry["p"] as? Int {
+            guard p >= 0 else {
+                throw CARReaderError.decodingFailed(
+                    "MST node \(nodeHex) entry \(index) prefix count \(p) is negative"
+                )
+            }
+            return p
+        }
+
+        throw CARReaderError.decodingFailed(
+            "MST node \(nodeHex) entry \(index) is missing its required integer 'p' prefix count"
+        )
     }
 
-    // "e" — entries array
-    guard let entries = node["e"] as? [[String: Any]] else {
-      return // Leaf with no entries
+    private func entryKeySuffix(
+        _ entry: [String: Any],
+        nodeHex: String,
+        index: Int
+    ) throws -> String {
+        if let kData = entry["k"] as? Data {
+            guard let keySuffix = String(data: kData, encoding: .utf8) else {
+                throw CARReaderError.decodingFailed(
+                    "MST node \(nodeHex) entry \(index) key suffix is not valid UTF-8"
+                )
+            }
+            return keySuffix
+        }
+
+        if let kString = entry["k"] as? String {
+            return kString
+        }
+
+        throw CARReaderError.decodingFailed(
+            "MST node \(nodeHex) entry \(index) is missing its required 'k' key suffix"
+        )
     }
-
-    var lastKey = prefix
-
-    for entry in entries {
-      // "p" — how many characters of the previous key to keep as prefix
-      let prefixCount: Int
-      if let p = entry["p"] as? UInt64 {
-        prefixCount = Int(p)
-      } else if let p = entry["p"] as? Int {
-        prefixCount = p
-      } else {
-        prefixCount = 0
-      }
-
-      // "k" — key suffix as bytes
-      let keySuffix: String
-      if let kData = entry["k"] as? Data {
-        keySuffix = String(data: kData, encoding: .utf8) ?? ""
-      } else if let kString = entry["k"] as? String {
-        keySuffix = kString
-      } else {
-        continue
-      }
-
-      // Build full key: take `prefixCount` chars from previous key + suffix
-      let prefixPart = String(lastKey.prefix(prefixCount))
-      let fullKey = prefixPart + keySuffix
-      lastKey = fullKey
-
-      // "v" — value CID (the record)
-      if let valueCID = entry["v"] as? CID {
-        try onRecord(fullKey, valueCID)
-      }
-
-      // "t" — optional right subtree
-      if let treeCID = entry["t"] as? CID {
-        try walkMSTNode(cid: treeCID, prefix: prefix, onRecord: onRecord)
-      }
-    }
-  }
 }

--- a/Sources/Petrel/Storage/AppleKeychainStore.swift
+++ b/Sources/Petrel/Storage/AppleKeychainStore.swift
@@ -675,25 +675,40 @@
                     throw KeychainError.dataFormatError
                 }
 
-                // Try to delete SecKey
+                // Both representations are live key material — retrieval reads either — so
+                // attempt both deletions independently and only then report the first
+                // failure; a SecKey failure must not strand the password fallback.
+                var firstFailure: (any Error)?
+
                 let keyQuery: [String: Any] = [
                     kSecClass as String: kSecClassKey,
                     kSecAttrApplicationTag as String: tagData,
                 ].merging(Self.accessGroupAttributes(accessGroup)) { _, new in new }
                 let keyStatus = SecItemDelete(keyQuery as CFDictionary)
                 LogManager.logDebug("AppleKeychainStore - macOS SecKey delete status: \(keyStatus)")
-                // Both representations are live key material — retrieval reads either — so a
-                // failure to remove one must not be reported as a deleted key.
-                guard keyStatus == errSecSuccess || keyStatus == errSecItemNotFound else {
+                if keyStatus != errSecSuccess, keyStatus != errSecItemNotFound {
                     LogManager.logError(
                         "AppleKeychainStore - Failed to delete macOS SecKey for tag \(keyTag). Status: \(keyStatus)"
                     )
-                    throw KeychainError.deletionError(status: Int(keyStatus))
+                    firstFailure = KeychainError.deletionError(status: Int(keyStatus))
                 }
 
                 // Delete password fallback (tolerates a missing item)
                 let passwordKey = "\(keyTag).password"
-                try delete(key: passwordKey, namespace: "dpopkeys", accessGroup: accessGroup)
+                do {
+                    try delete(key: passwordKey, namespace: "dpopkeys", accessGroup: accessGroup)
+                } catch {
+                    LogManager.logError(
+                        "AppleKeychainStore - Failed to delete password fallback for tag \(keyTag): \(error)"
+                    )
+                    if firstFailure == nil {
+                        firstFailure = error
+                    }
+                }
+
+                if let firstFailure {
+                    throw firstFailure
+                }
             }
         #endif
     }

--- a/Sources/Petrel/Storage/AppleKeychainStore.swift
+++ b/Sources/Petrel/Storage/AppleKeychainStore.swift
@@ -682,10 +682,18 @@
                 ].merging(Self.accessGroupAttributes(accessGroup)) { _, new in new }
                 let keyStatus = SecItemDelete(keyQuery as CFDictionary)
                 LogManager.logDebug("AppleKeychainStore - macOS SecKey delete status: \(keyStatus)")
+                // Both representations are live key material — retrieval reads either — so a
+                // failure to remove one must not be reported as a deleted key.
+                guard keyStatus == errSecSuccess || keyStatus == errSecItemNotFound else {
+                    LogManager.logError(
+                        "AppleKeychainStore - Failed to delete macOS SecKey for tag \(keyTag). Status: \(keyStatus)"
+                    )
+                    throw KeychainError.deletionError(status: Int(keyStatus))
+                }
 
-                // Try to delete password fallback
+                // Delete password fallback (tolerates a missing item)
                 let passwordKey = "\(keyTag).password"
-                try? delete(key: passwordKey, namespace: "dpopkeys", accessGroup: accessGroup)
+                try delete(key: passwordKey, namespace: "dpopkeys", accessGroup: accessGroup)
             }
         #endif
     }

--- a/Sources/Petrel/Storage/FileEncryptedStore.swift
+++ b/Sources/Petrel/Storage/FileEncryptedStore.swift
@@ -171,9 +171,31 @@
             return decrypted
         }
 
+        /// A secret that is already absent satisfies a delete; anything else — a
+        /// permission failure, a read-only volume — leaves the secret on disk and must
+        /// reach the caller rather than be reported as a successful wipe.
+        private func isFileNotFound(_ error: any Error) -> Bool {
+            if let cocoaError = error as? CocoaError {
+                return cocoaError.code == .fileNoSuchFile
+            }
+            let nsError = error as NSError
+            return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError
+        }
+
         func delete(key: String, namespace: String, accessGroup: String?) throws {
             let url = fileURL(for: key, namespace: namespace)
-            try? FileManager.default.removeItem(at: url)
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch {
+                guard isFileNotFound(error) else {
+                    LogManager.logError(
+                        "FileEncryptedStore: Failed to delete key \(namespace).\(key): \(error)"
+                    )
+                    throw error
+                }
+                LogManager.logDebug("FileEncryptedStore: No stored value for key \(namespace).\(key)")
+                return
+            }
             LogManager.logDebug("FileEncryptedStore: Deleted key \(namespace).\(key)")
         }
 
@@ -183,6 +205,7 @@
                 includingPropertiesForKeys: nil
             )
             var deletedCount = 0
+            var failures: [any Error] = []
             for file in files {
                 // Decode filename to check namespace
                 let filename = file.lastPathComponent
@@ -192,9 +215,25 @@
                    let namespacedKey = String(data: decoded, encoding: .utf8),
                    namespacedKey.hasPrefix("\(namespace).")
                 {
-                    try? FileManager.default.removeItem(at: file)
-                    deletedCount += 1
+                    do {
+                        try FileManager.default.removeItem(at: file)
+                        deletedCount += 1
+                    } catch {
+                        // Keep going so one unremovable file cannot strand the rest of the
+                        // namespace, then fail once every remaining secret has been attempted.
+                        guard isFileNotFound(error) else {
+                            failures.append(error)
+                            continue
+                        }
+                    }
                 }
+            }
+            if let firstFailure = failures.first {
+                LogManager.logError("""
+                FileEncryptedStore: Deleted \(deletedCount) items for namespace \(namespace) but \
+                \(failures.count) could not be removed. First failure: \(firstFailure)
+                """)
+                throw firstFailure
             }
             LogManager.logInfo("FileEncryptedStore: Deleted \(deletedCount) items for namespace: \(namespace)")
         }

--- a/Tests/PetrelTests/CARStrictnessTests.swift
+++ b/Tests/PetrelTests/CARStrictnessTests.swift
@@ -1,0 +1,334 @@
+import Foundation
+@testable import Petrel
+import Testing
+
+/// Minimal CBOR writer. The production encoder rejects the malformed shapes these
+/// tests need, so fixtures are assembled byte by byte.
+private enum TestCBOR {
+    static func header(major: UInt8, argument: UInt64) -> Data {
+        let prefix = major << 5
+        var result = Data()
+        switch argument {
+        case 0 ..< 24:
+            result.append(prefix | UInt8(argument))
+        case 24 ... UInt64(UInt8.max):
+            result.append(prefix | 24)
+            result.append(UInt8(argument))
+        case (UInt64(UInt8.max) + 1) ... UInt64(UInt16.max):
+            result.append(prefix | 25)
+            var value = UInt16(argument).bigEndian
+            result.append(Data(bytes: &value, count: MemoryLayout<UInt16>.size))
+        case (UInt64(UInt16.max) + 1) ... UInt64(UInt32.max):
+            result.append(prefix | 26)
+            var value = UInt32(argument).bigEndian
+            result.append(Data(bytes: &value, count: MemoryLayout<UInt32>.size))
+        default:
+            result.append(prefix | 27)
+            var value = argument.bigEndian
+            result.append(Data(bytes: &value, count: MemoryLayout<UInt64>.size))
+        }
+        return result
+    }
+
+    static func uint(_ value: UInt64) -> Data {
+        header(major: 0, argument: value)
+    }
+
+    static func negative(_ value: Int64) -> Data {
+        header(major: 1, argument: UInt64(-1 - value))
+    }
+
+    static func bytes(_ value: Data) -> Data {
+        header(major: 2, argument: UInt64(value.count)) + value
+    }
+
+    static func text(_ value: String) -> Data {
+        let utf8 = Data(value.utf8)
+        return header(major: 3, argument: UInt64(utf8.count)) + utf8
+    }
+
+    static func array(_ items: [Data]) -> Data {
+        items.reduce(header(major: 4, argument: UInt64(items.count))) { $0 + $1 }
+    }
+
+    static func map(_ pairs: [(String, Data)]) -> Data {
+        pairs.reduce(header(major: 5, argument: UInt64(pairs.count))) { $0 + text($1.0) + $1.1 }
+    }
+
+    static func link(_ cid: CID) -> Data {
+        header(major: 6, argument: 42) + bytes(Data([0x00]) + cid.bytes)
+    }
+}
+
+/// Assembles CAR v1 archives from hand-built blocks.
+private struct TestCARBuilder {
+    private var blocks: [(cid: CID, payload: Data)] = []
+
+    static func varint(_ value: Int) -> Data {
+        var remaining = UInt64(value)
+        var result = Data()
+        repeat {
+            var byte = UInt8(remaining & 0x7F)
+            remaining >>= 7
+            if remaining != 0 { byte |= 0x80 }
+            result.append(byte)
+        } while remaining != 0
+        return result
+    }
+
+    mutating func add(_ payload: Data) -> CID {
+        let cid = CID.fromDAGCBOR(payload)
+        blocks.append((cid, payload))
+        return cid
+    }
+
+    func archive(root: CID) -> Data {
+        let header = TestCBOR.map([
+            ("roots", TestCBOR.array([TestCBOR.link(root)])),
+            ("version", TestCBOR.uint(1)),
+        ])
+
+        var result = Self.varint(header.count) + header
+        for block in blocks {
+            let framed = block.cid.bytes + block.payload
+            result += Self.varint(framed.count) + framed
+        }
+        return result
+    }
+}
+
+@Suite("CAR and MST structural strictness")
+struct CARStrictnessTests {
+    private static let recordKey = "app.bsky.feed.post/3kabcdefghij"
+
+    /// Builds a single-record repository whose MST root entry is `entryOverride`
+    /// (defaulting to a well-formed entry) and returns the archive bytes.
+    private func archive(
+        entryOverride: ((CID) -> Data)? = nil,
+        rootNodeOverride: ((Data) -> Data)? = nil,
+        recordType: String = "app.bsky.feed.post"
+    ) -> Data {
+        var builder = TestCARBuilder()
+
+        let recordCID = builder.add(TestCBOR.map([
+            ("$type", TestCBOR.text(recordType)),
+            ("text", TestCBOR.text("hello")),
+            ("createdAt", TestCBOR.text("2026-01-01T00:00:00.000Z")),
+        ]))
+
+        let entry = entryOverride?(recordCID) ?? TestCBOR.map([
+            ("p", TestCBOR.uint(0)),
+            ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+            ("v", TestCBOR.link(recordCID)),
+        ])
+
+        let defaultRootNode = TestCBOR.map([("e", TestCBOR.array([entry]))])
+        let rootNodeCID = builder.add(rootNodeOverride?(entry) ?? defaultRootNode)
+
+        let commitCID = builder.add(TestCBOR.map([
+            ("did", TestCBOR.text("did:plc:testtesttesttesttesttest")),
+            ("version", TestCBOR.uint(3)),
+            ("data", TestCBOR.link(rootNodeCID)),
+        ]))
+
+        return builder.archive(root: commitCID)
+    }
+
+    private func parse(_ archive: Data) throws -> (CARRepository.Stats, [CARRepository.Record]) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("petrel-car-test-\(UUID().uuidString).car")
+        try archive.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var records: [CARRepository.Record] = []
+        let stats = try CARRepository.parse(fileURL: url) { records.append($0) }
+        return (stats, records)
+    }
+
+    // MARK: - Well-formed input
+
+    @Test("A well-formed repository still parses")
+    func wellFormedArchiveParses() throws {
+        let (stats, records) = try parse(archive())
+
+        #expect(stats.blockCount == 3)
+        #expect(stats.recordCount == 1)
+        #expect(stats.decodedCount == 1)
+        #expect(stats.failedCount == 0)
+        #expect(records.count == 1)
+        #expect(records.first?.collection == "app.bsky.feed.post")
+        #expect(records.first?.rkey == "3kabcdefghij")
+    }
+
+    @Test("An MST node with no entries is not corruption")
+    func emptyEntriesArrayParses() throws {
+        let archive = archive(rootNodeOverride: { _ in
+            TestCBOR.map([("e", TestCBOR.array([]))])
+        })
+
+        let (stats, records) = try parse(archive)
+
+        #expect(stats.recordCount == 0)
+        #expect(records.isEmpty)
+    }
+
+    @Test("Records with no matching Lexicon type are reported as downgraded")
+    func unknownRecordTypeIsCountedAsDowngraded() throws {
+        let (stats, _) = try parse(archive(recordType: "com.example.notALexicon"))
+
+        #expect(stats.decodedCount == 1)
+        #expect(stats.downgradedCount == 1)
+        #expect(stats.failedCount == 0)
+    }
+
+    // MARK: - MST structure
+
+    @Test("A missing entries array throws")
+    func missingEntriesArrayThrows() throws {
+        let archive = archive(rootNodeOverride: { _ in
+            TestCBOR.map([("l", Data([0xF6]))])
+        })
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A non-map element in the entries array throws")
+    func nonMapEntryElementThrows() throws {
+        let archive = archive(rootNodeOverride: { entry in
+            TestCBOR.map([("e", TestCBOR.array([entry, TestCBOR.text("not an entry")]))])
+        })
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A missing prefix count throws instead of defaulting to zero")
+    func missingPrefixCountThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A non-integer prefix count throws")
+    func nonIntegerPrefixCountThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("p", TestCBOR.text("0")),
+                ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A negative prefix count throws")
+    func negativePrefixCountThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("p", TestCBOR.negative(-1)),
+                ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A prefix count longer than the previous key throws")
+    func overlongPrefixCountThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("p", TestCBOR.uint(4)),
+                ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A missing key suffix throws instead of dropping the record")
+    func missingKeySuffixThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("p", TestCBOR.uint(0)),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A key suffix that is not valid UTF-8 throws")
+    func invalidUTF8KeySuffixThrows() throws {
+        let archive = archive { recordCID in
+            TestCBOR.map([
+                ("p", TestCBOR.uint(0)),
+                ("k", TestCBOR.bytes(Data([0xFF, 0xFE, 0xFD]))),
+                ("v", TestCBOR.link(recordCID)),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A missing value CID throws instead of dropping the record")
+    func missingValueCIDThrows() throws {
+        let archive = archive { _ in
+            TestCBOR.map([
+                ("p", TestCBOR.uint(0)),
+                ("k", TestCBOR.bytes(Data(Self.recordKey.utf8))),
+            ])
+        }
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    // MARK: - Block framing
+
+    @Test("A truncated archive throws instead of indexing as a partial one")
+    func truncatedArchiveThrows() throws {
+        let complete = archive()
+        let truncated = complete.prefix(complete.count - 8)
+
+        #expect(throws: CARReaderError.self) { try parse(Data(truncated)) }
+    }
+
+    @Test("A truncated block-length varint throws instead of ending the scan")
+    func truncatedVarintThrows() throws {
+        // 0x81 sets the continuation bit with no byte following it.
+        let archive = archive() + Data([0x81])
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A block length that overruns the archive throws")
+    func overlongBlockLengthThrows() throws {
+        var archive = archive()
+        archive += TestCARBuilder.varint(4096)
+        archive += Data(repeating: 0x00, count: 16)
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A zero-length block throws")
+    func zeroLengthBlockThrows() throws {
+        let archive = archive() + Data([0x00])
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+
+    @Test("A CID that overruns its own block throws")
+    func cidOverrunningBlockThrows() throws {
+        // A four-byte block claiming a 32-byte multihash digest.
+        let block = Data([0x01, 0x71, 0x12, 0x20])
+        let archive = archive() + TestCARBuilder.varint(block.count) + block
+
+        #expect(throws: CARReaderError.self) { try parse(archive) }
+    }
+}

--- a/Tests/PetrelTests/FileEncryptedStoreDeletionTests.swift
+++ b/Tests/PetrelTests/FileEncryptedStoreDeletionTests.swift
@@ -1,0 +1,136 @@
+#if os(macOS) || os(iOS)
+    #if canImport(CryptoKit)
+        import CryptoKit
+    #else
+        import Crypto
+    #endif
+    import Foundation
+    @testable import Petrel
+    import Testing
+
+    @Suite("File-encrypted secure storage deletion")
+    struct FileEncryptedStoreDeletionTests {
+        private func withStore<T>(
+            _ body: (FileEncryptedStore, URL, String) throws -> T
+        ) throws -> T {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("petrel-file-store-delete-tests-\(UUID().uuidString)")
+            let namespace = "petrel-file-store-delete-test-\(UUID().uuidString)"
+            let store = try FileEncryptedStore(
+                storageDirectory: directory,
+                masterKey: SymmetricKey(size: .bits256)
+            )
+            defer {
+                // Restore write permission first: a failure test may have removed it.
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o700],
+                    ofItemAtPath: directory.path
+                )
+                try? FileManager.default.removeItem(at: directory)
+            }
+            return try body(store, directory, namespace)
+        }
+
+        private func denyWrites(to directory: URL) throws {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o500],
+                ofItemAtPath: directory.path
+            )
+        }
+
+        @Test("Deleting a stored value removes it")
+        func deleteRemovesStoredValue() throws {
+            try withStore { store, _, namespace in
+                try store.store(
+                    key: "token",
+                    value: Data("private value".utf8),
+                    namespace: namespace,
+                    accessGroup: nil
+                )
+
+                try store.delete(key: "token", namespace: namespace, accessGroup: nil)
+
+                #expect(throws: KeychainError.self) {
+                    try store.retrieve(key: "token", namespace: namespace, accessGroup: nil)
+                }
+            }
+        }
+
+        @Test("Deleting a value that was never stored succeeds")
+        func deleteToleratesMissingValue() throws {
+            try withStore { store, _, namespace in
+                try store.delete(key: "missing", namespace: namespace, accessGroup: nil)
+            }
+        }
+
+        @Test("A delete that cannot remove the secret throws")
+        func deleteSurfacesRemovalFailure() throws {
+            try withStore { store, directory, namespace in
+                try store.store(
+                    key: "token",
+                    value: Data("private value".utf8),
+                    namespace: namespace,
+                    accessGroup: nil
+                )
+                try denyWrites(to: directory)
+
+                #expect(throws: (any Error).self) {
+                    try store.delete(key: "token", namespace: namespace, accessGroup: nil)
+                }
+                // The secret is still readable, which is exactly why the throw matters.
+                let survivor = try store.retrieve(key: "token", namespace: namespace, accessGroup: nil)
+                #expect(survivor == Data("private value".utf8))
+            }
+        }
+
+        @Test("Deleting a namespace removes every value in it")
+        func deleteAllRemovesNamespace() throws {
+            try withStore { store, _, namespace in
+                let otherNamespace = "petrel-file-store-other-\(UUID().uuidString)"
+                for key in ["one", "two"] {
+                    try store.store(
+                        key: key,
+                        value: Data(key.utf8),
+                        namespace: namespace,
+                        accessGroup: nil
+                    )
+                }
+                try store.store(
+                    key: "kept",
+                    value: Data("kept".utf8),
+                    namespace: otherNamespace,
+                    accessGroup: nil
+                )
+
+                try store.deleteAll(namespace: namespace, accessGroup: nil)
+
+                for key in ["one", "two"] {
+                    #expect(throws: KeychainError.self) {
+                        try store.retrieve(key: key, namespace: namespace, accessGroup: nil)
+                    }
+                }
+                let kept = try store.retrieve(key: "kept", namespace: otherNamespace, accessGroup: nil)
+                #expect(kept == Data("kept".utf8))
+            }
+        }
+
+        @Test("A namespace wipe that removes nothing throws instead of reporting success")
+        func deleteAllSurfacesRemovalFailure() throws {
+            try withStore { store, directory, namespace in
+                for key in ["one", "two"] {
+                    try store.store(
+                        key: key,
+                        value: Data(key.utf8),
+                        namespace: namespace,
+                        accessGroup: nil
+                    )
+                }
+                try denyWrites(to: directory)
+
+                #expect(throws: (any Error).self) {
+                    try store.deleteAll(namespace: namespace, accessGroup: nil)
+                }
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
Part of the `try?`/silent-failure audit following #23. CAR/MST parsing could return **wrong success** on corrupt input, and storage deletion could **report success without deleting**. Both classes are fixed here; per-record decode failures keep their existing counted-not-thrown contract — only *structural* corruption is promoted to thrown errors.

## CAR / MST strictness

- **`MSTTraverser.walkMSTNode`**: the required `e` entries array, per-entry `p` prefix count, `k` key suffix, and `v` value CID now throw `CARReaderError.decodingFailed` with the node CID and entry index, instead of silently dropping the node (and every right subtree hanging off it), zeroing the prefix, collapsing invalid UTF-8 keys to `""`, or skipping the record. Keys are prefix-compressed against the previous entry, so one bad entry previously corrupted every subsequent key in the node. Prefix count is also bounds-checked against the previous key's length.
- **`CARReader.indexBlocks`**: malformed varints and block-framing violations now throw (`invalidVarint` / `unexpectedEOF`) instead of being treated as clean end-of-archive — a truncated CAR can no longer index as a smaller but seemingly intact one. The only clean end of the archive is a block ending exactly at `data.count`. Intra-block CID bounds checks now guard against the block end rather than the buffer end.
- **`CARRepository.Stats.downgradedCount`** (new): records that decoded but matched no generated Lexicon type (preserved as `.unknownType`) are counted, so schema drift is no longer indistinguishable from a fully clean decode.

## Storage deletion honesty

- **`FileEncryptedStore.delete`**: propagates removal failures (tolerating only file-not-found) instead of `try?`-swallowing and logging success — a locked file or read-only volume no longer leaves a sealed token blob on disk behind a "Deleted" log line.
- **`FileEncryptedStore.deleteAll`**: `deletedCount` now counts real deletions, individual failures don't stop the rest of the namespace wipe, and the first failure is thrown after all secrets have been attempted.
- **`AppleKeychainStore.deleteDPoPKeymacOS`**: the `SecItemDelete` status is now checked (`errSecSuccess`/`errSecItemNotFound` accepted) and the password-fallback delete propagates; both representations are live key material, so a failed removal must not be reported as a deleted key.

## Tests

Two new suites, 22 tests total, all constructing minimal CAR/CBOR fixtures by hand:
- `CARStrictnessTests` — MST node with a non-map entry element throws; missing `p`/`k`/`v` throws; invalid UTF-8 key throws; prefix overrun throws; truncated CAR throws instead of partial success; `downgradedCount` surfaces unknown-type records; valid repos still parse.
- `FileEncryptedStoreDeletionTests` — delete throws on failure but tolerates a missing file; deleteAll continues past individual failures and reports honestly.

Full suite green on the Xcode-beta toolchain (`swift test`: all XCTest + Swift Testing suites + PetrelLoad, 0 failures). swiftformat run over all changed files. Also adds `.build-xcbeta/` to `.gitignore` (scratch path used to work around the local default-toolchain/SDK mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTnE6vV45eVCUwQzpMddf6
