### PR TITLE
generator tests: track re-encode guard rename in projection assertion

### DIFF
--- a/generator/tests/test_generated_projection.py
+++ b/generator/tests/test_generated_projection.py
@@ -1375,7 +1375,11 @@ class GeneratorProjectionPublicationTests(unittest.TestCase):
         self.assertIn("case \"$link\":", value_container)
         self.assertIn("case \"$bytes\":", value_container)
         self.assertIn(
-            "typedValue.encodedDAGCBOR() == rawObject.encodedDAGCBOR()",
+            "try !dagCBOREqualIgnoringTypeFraming(typedValue, rawObject)",
+            value_container,
+        )
+        self.assertIn(
+            "!isSpecTolerantMatch(typed: typedValue, raw: rawObject)",
             value_container,
         )
         self.assertIn("try container.decodeNil(forKey: key)", value_container)


### PR DESCRIPTION
## Why every PR's CI is red

`test_core_manifest_publishes_one_complete_projection` still asserts the generated `ATProtocolValueContainer.swift` contains the old byte-exact re-encode guard:

```
typedValue.encodedDAGCBOR() == rawObject.encodedDAGCBOR()
```

The container-dispatch changes (db84b2c9 "ignore unknown record fields per atproto spec" and 50a5dda4 "tolerate informationless wire variances in re-encode guard") replaced that comparison with `dagCBOREqualIgnoringTypeFraming` + `isSpecTolerantMatch`, but the assertion was never updated. **Generator determinism** and both **macOS release gate** jobs have been failing on `main` since 2026-07-22 (visible on the PR #23 merge run), and PRs #24–#27 inherit the failure through the merge ref.

## Fix

Assert the two current guard markers instead:
- `try !dagCBOREqualIgnoringTypeFraming(typedValue, rawObject)`
- `!isSpecTolerantMatch(typed: typedValue, raw: rawObject)`

## Verification

`python3 -m unittest generator.tests.test_generated_projection` — 53 tests, OK (was 1 failure).

Once merged, re-running the failed checks on #24–#27 should go green (they run on the merge ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTnE6vV45eVCUwQzpMddf6