### PR TITLE
tests: scope unrepresentable-incident probe to its own DID

### DIFF
--- a/Tests/PetrelTests/LogManagerTests.swift
+++ b/Tests/PetrelTests/LogManagerTests.swift
@@ -170,17 +170,22 @@ struct LogManagerTests {
             await recorder.record(event)
         }
 
+        // Unique to this test: the broadcast bus is global, so suites running in
+        // parallel deliver their own incidents to this observer. Only an event
+        // carrying this DID would prove the unrepresentable incident leaked through.
+        let did = "did:plc:unrepresentable-incident-probe"
         LogManager.logAuthIncident(
             "InvalidGrantWithValidToken",
             details: [
-                "did": "did:plc:valid",
+                "did": did,
                 "tokenExpiresIn": "3600.0",
                 "description": "session preserved",
             ]
         )
         await PetrelAuthEvents.drain()
 
-        #expect(await recorder.events.isEmpty)
+        let leaked = await recorder.events.filter { String(describing: $0).contains(did) }
+        #expect(leaked.isEmpty)
         await PetrelAuthEvents.removeAllObservers()
     }
 


### PR DESCRIPTION
Fixes the cross-suite flake that failed **Swift compatibility / macOS (newest-stable)** on the PR #26 merge commit ([run 30637596063](https://github.com/joshlacal/Petrel/actions/runs/30637596063)).

`Unrepresentable incidents are not delivered to typed observers` registers an observer on the global `PetrelAuthEvents` bus and asserted `recorder.events.isEmpty`. The suite is `.serialized`, but that only serializes within the suite — other suites run in parallel and their auth error paths (now exercised much more heavily by the tests added in #24/#25) legitimately deliver typed events to that observer. The same tree passed on Linux, macOS (minimum), and locally.

The test now logs its incident with a unique probe DID and asserts no recorded event carries that DID — concurrent-suite traffic is ignored while a genuine leak of the unrepresentable incident still fails the test.

Verified: `swift test --filter LogManagerTests` — 14 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTnE6vV45eVCUwQzpMddf6