### PR TITLE
Persist and validate granted OAuth scopes

### DIFF
--- a/Sources/Petrel/Auth/AuthManager.swift
+++ b/Sources/Petrel/Auth/AuthManager.swift
@@ -267,6 +267,22 @@ actor AuthManager: AuthStrategy, AuthContinuityProviding {
         try await activeStrategy.attemptRecoveryFromServerFailures(for: did)
     }
 
+    func grantedScopes(for did: String?) async -> Set<String> {
+        let targetDID: String?
+        if let did {
+            targetDID = did
+        } else {
+            targetDID = await accountManager.getCurrentAccount()?.did
+        }
+
+        guard let targetDID,
+              let session = try? await storage.getSession(for: targetDID)
+        else {
+            return []
+        }
+        return session.grantedScopes
+    }
+
     // MARK: - AuthenticationProvider Forwarding
 
     func prepareAuthenticatedRequest(_ request: URLRequest) async throws -> URLRequest {

--- a/Sources/Petrel/Auth/AuthenticationService.swift
+++ b/Sources/Petrel/Auth/AuthenticationService.swift
@@ -567,7 +567,8 @@ actor AuthenticationService: AuthServiceProtocol, AuthStrategy, AuthenticationPr
             createdAt: Date(), // Use current time
             expiresIn: adjustedExpiresIn,
             tokenType: tokenType,
-            did: did
+            did: did,
+            grantedScopes: tokenResponse.grantedScopes
         )
         LogManager.logDebug("Created new session for DID: \(did)")
 
@@ -2166,7 +2167,8 @@ actor AuthenticationService: AuthServiceProtocol, AuthStrategy, AuthenticationPr
                     createdAt: Date(), // Use current time as the refresh time
                     expiresIn: adjustedExpiresIn,
                     tokenType: session.tokenType, // Assume token type doesn't change on refresh
-                    did: account.did
+                    did: account.did,
+                    grantedScopes: tokenResponse.grantedScopes
                 )
 
                 // Save session with enhanced validation
@@ -2289,7 +2291,8 @@ actor AuthenticationService: AuthServiceProtocol, AuthStrategy, AuthenticationPr
                             createdAt: Date(),
                             expiresIn: adjustedExpiresIn,
                             tokenType: session.tokenType,
-                            did: account.did
+                            did: account.did,
+                            grantedScopes: tokenResponse.grantedScopes
                         )
                         try await storage.saveSession(newSession, for: account.did)
 
@@ -4127,6 +4130,10 @@ struct TokenResponse: Decodable {
     let sub: String?
     let dpopJkt: String?
 
+    var grantedScopes: Set<String> {
+        Set(scope.split(whereSeparator: \.isWhitespace).map(String.init))
+    }
+
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
         case tokenType = "token_type"
@@ -4135,6 +4142,25 @@ struct TokenResponse: Decodable {
         case scope
         case sub
         case dpopJkt = "dpop_jkt"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        tokenType = try container.decode(String.self, forKey: .tokenType)
+        expiresIn = try container.decode(Int.self, forKey: .expiresIn)
+        refreshToken = try container.decode(String.self, forKey: .refreshToken)
+        scope = try container.decode(String.self, forKey: .scope)
+        sub = try container.decodeIfPresent(String.self, forKey: .sub)
+        dpopJkt = try container.decodeIfPresent(String.self, forKey: .dpopJkt)
+
+        guard grantedScopes.contains("atproto") else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .scope,
+                in: container,
+                debugDescription: "OAuth token response scope must contain atproto"
+            )
+        }
     }
 }
 

--- a/Sources/Petrel/Auth/AuthenticationService.swift
+++ b/Sources/Petrel/Auth/AuthenticationService.swift
@@ -3602,10 +3602,19 @@ actor AuthenticationService: AuthServiceProtocol, AuthStrategy, AuthenticationPr
     /// - Parameter params: The parameters to encode.
     /// - Returns: The encoded data.
     private func encodeFormData(_ params: [String: String]) -> Data {
+        // `.urlQueryAllowed` permits '&', '=', and '+' (they're legal within a query
+        // component overall), but those are exactly the delimiters this method uses to
+        // join key/value pairs. A value containing a literal '&' or '=' — e.g. an atproto
+        // rich-scope entry like "repo:com.getorbyt.profile?action=create&action=update" —
+        // would otherwise leak an extra '&'/'=' into the encoded body and get split into
+        // bogus extra form fields by the receiving server, silently truncating the value.
+        var formValueAllowed = CharacterSet.urlQueryAllowed
+        formValueAllowed.remove(charactersIn: "&=+;")
+
         let queryItems = params.map { key, value in
-            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? key
             let escapedValue =
-                value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+                value.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? value
             return "\(escapedKey)=\(escapedValue)"
         }
 

--- a/Sources/Petrel/Auth/OAuth/OAuthCore.swift
+++ b/Sources/Petrel/Auth/OAuth/OAuthCore.swift
@@ -101,9 +101,15 @@ actor OAuthCore {
     }
 
     func encodeFormData(_ params: [String: String]) -> Data {
+        // See AuthenticationService.encodeFormData: '&'/'='/'+' must not stay in the
+        // per-value allowed set or a value containing them (e.g. a rich-scope entry with
+        // an embedded '&') collides with the delimiters joining key/value pairs below.
+        var formValueAllowed = CharacterSet.urlQueryAllowed
+        formValueAllowed.remove(charactersIn: "&=+;")
+
         let queryItems = params.map { key, value in
-            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
-            let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+            let escapedKey = key.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? key
+            let escapedValue = value.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? value
             return "\(escapedKey)=\(escapedValue)"
         }
         return queryItems.joined(separator: "&").data(using: .utf8) ?? Data()

--- a/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/CABOAuthStrategy.swift
@@ -172,7 +172,8 @@ actor CABOAuthStrategy: AuthStrategy {
             createdAt: Date(),
             expiresIn: TimeInterval(tokenResponse.expiresIn),
             tokenType: .dpop,
-            did: did
+            did: did,
+            grantedScopes: tokenResponse.grantedScopes
         )
 
         // Create/Update Account
@@ -619,7 +620,8 @@ actor CABOAuthStrategy: AuthStrategy {
                 createdAt: Date(),
                 expiresIn: TimeInterval(tokenResponse.expiresIn),
                 tokenType: session.tokenType,
-                did: account.did
+                did: account.did,
+                grantedScopes: tokenResponse.grantedScopes
             )
             // The server has rotated the refresh token; persistence failures are handled
             // inside (retry + pending key + in-memory) and must not fail the refresh.

--- a/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
+++ b/Sources/Petrel/Auth/Strategies/PublicOAuthStrategy.swift
@@ -194,7 +194,8 @@ actor PublicOAuthStrategy: AuthStrategy {
             createdAt: Date(),
             expiresIn: TimeInterval(tokenResponse.expiresIn),
             tokenType: .dpop,
-            did: did
+            did: did,
+            grantedScopes: tokenResponse.grantedScopes
         )
 
         // Create/Update Account
@@ -548,7 +549,8 @@ actor PublicOAuthStrategy: AuthStrategy {
                 createdAt: Date(),
                 expiresIn: TimeInterval(tokenResponse.expiresIn),
                 tokenType: session.tokenType,
-                did: account.did
+                did: account.did,
+                grantedScopes: tokenResponse.grantedScopes
             )
             // The server has rotated the refresh token; persistence failures are handled
             // inside (retry + pending key + in-memory) and must not fail the refresh.

--- a/Sources/Petrel/Core/Types/ATProtoModels.swift
+++ b/Sources/Petrel/Core/Types/ATProtoModels.swift
@@ -160,6 +160,11 @@ public struct Session: Codable, Equatable, Sendable {
     /// The DID associated with this session
     public let did: String
 
+    /// The exact OAuth scopes granted by the authorization server.
+    /// Legacy password sessions and sessions written by Petrel versions before
+    /// 1.0.0 do not have a granted scope set.
+    public let grantedScopes: Set<String>
+
     /// Whether the token has expired
     public var isExpired: Bool {
         Date() > createdAt.addingTimeInterval(expiresIn)
@@ -185,7 +190,8 @@ public struct Session: Codable, Equatable, Sendable {
         createdAt: Date,
         expiresIn: TimeInterval,
         tokenType: TokenType,
-        did: String
+        did: String,
+        grantedScopes: Set<String> = []
     ) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
@@ -193,6 +199,28 @@ public struct Session: Codable, Equatable, Sendable {
         self.expiresIn = expiresIn
         self.tokenType = tokenType
         self.did = did
+        self.grantedScopes = grantedScopes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken
+        case refreshToken
+        case createdAt
+        case expiresIn
+        case tokenType
+        case did
+        case grantedScopes
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try container.decode(String.self, forKey: .accessToken)
+        refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        expiresIn = try container.decode(TimeInterval.self, forKey: .expiresIn)
+        tokenType = try container.decode(TokenType.self, forKey: .tokenType)
+        did = try container.decode(String.self, forKey: .did)
+        grantedScopes = try container.decodeIfPresent(Set<String>.self, forKey: .grantedScopes) ?? []
     }
 }
 

--- a/Sources/Petrel/Generated/Client/ATProtoClient+Generated.swift
+++ b/Sources/Petrel/Generated/Client/ATProtoClient+Generated.swift
@@ -687,6 +687,12 @@ public actor ATProtoClient {
         return await accountManager?.getCurrentAccount()
     }
 
+    /// Returns the exact scopes granted to an OAuth account.
+    /// - Parameter did: The account DID, or `nil` for the active account.
+    public func getGrantedScopes(for did: String? = nil) async -> Set<String> {
+        await authManager?.grantedScopes(for: did) ?? []
+    }
+
     // MARK: - DID Resolution
 
     /// Resolves a handle to a DID.

--- a/Tests/PetrelTests/Auth/OAuthGrantedScopeTests.swift
+++ b/Tests/PetrelTests/Auth/OAuthGrantedScopeTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+@testable import Petrel
+import Testing
+
+@Suite("OAuth granted scope tests")
+struct OAuthGrantedScopeTests {
+    @Test("token response preserves exact granted scopes")
+    func tokenResponsePreservesGrantedScopes() throws {
+        let response = try JSONDecoder().decode(
+            TokenResponse.self,
+            from: tokenResponse(scope: "atproto repo:app.bsky.feed.post space")
+        )
+
+        #expect(response.grantedScopes == ["atproto", "repo:app.bsky.feed.post", "space"])
+    }
+
+    @Test("token response rejects a missing scope")
+    func tokenResponseRejectsMissingScope() {
+        let data = Data(
+            #"{"access_token":"access","token_type":"DPoP","expires_in":3600,"refresh_token":"refresh","sub":"did:plc:test"}"#.utf8
+        )
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(TokenResponse.self, from: data)
+        }
+    }
+
+    @Test("token response rejects a scope without atproto")
+    func tokenResponseRejectsMissingAtproto() {
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(
+                TokenResponse.self,
+                from: tokenResponse(scope: "repo:app.bsky.feed.post space")
+            )
+        }
+    }
+
+    @Test("sessions written before granted scope persistence remain readable")
+    func legacySessionRemainsReadable() throws {
+        let data = Data(
+            #"{"accessToken":"access","refreshToken":"refresh","createdAt":0,"expiresIn":3600,"tokenType":"dpop","did":"did:plc:test"}"#.utf8
+        )
+
+        let session = try JSONDecoder().decode(Session.self, from: data)
+        #expect(session.grantedScopes.isEmpty)
+    }
+
+    private func tokenResponse(scope: String) -> Data {
+        Data(
+            """
+            {
+              "access_token": "access",
+              "token_type": "DPoP",
+              "expires_in": 3600,
+              "refresh_token": "refresh",
+              "scope": "\(scope)",
+              "sub": "did:plc:test"
+            }
+            """.utf8
+        )
+    }
+}

--- a/Tests/PetrelTests/Auth/PARParameterTests.swift
+++ b/Tests/PetrelTests/Auth/PARParameterTests.swift
@@ -178,4 +178,38 @@ struct PARParameterTests {
     #expect(params["client_id"] == "https://override.example/meta.json")
     #expect(params.count == 7)
   }
+
+  @Test("Form encoding preserves '&' and '=' inside a rich-scope parameter value")
+  func formEncodingPreservesDelimitersInsideValues() async throws {
+    // Regression test: atproto rich permission-set scopes use '&' as an internal
+    // parameter separator, e.g. "repo:com.getorbyt.profile?action=create&action=update".
+    // .urlQueryAllowed permits '&'/'='/'+' unescaped, so encoding a value with that
+    // character set let a literal '&' inside the scope leak out and collide with the
+    // '&' joining top-level form fields — the receiving server split it into a bogus
+    // extra "action=update" field and silently truncated the scope. Assert the body
+    // round-trips through URLComponents (a real form-urlencoded parser) with exactly
+    // the fields we put in, and that the scope value is intact.
+    let core = makeCore(namespace: "test.par.formencoding")
+    let scope = "atproto repo:com.getorbyt.profile?action=create&action=update space"
+    let params = await core.buildPARParameters(
+      codeChallenge: "c", identifier: nil, state: "s", additionalParameters: nil
+    )
+    var mutableParams = params
+    mutableParams["scope"] = scope
+
+    let body = await core.encodeFormData(mutableParams)
+    let bodyString = try #require(String(data: body, encoding: .utf8))
+
+    var components = URLComponents()
+    components.percentEncodedQuery = bodyString
+    let queryItems = try #require(components.queryItems)
+
+    // Exactly one field per input parameter — no extra fields spawned by an
+    // unescaped '&' inside a value.
+    #expect(queryItems.count == mutableParams.count)
+
+    let decodedScope = queryItems.first(where: { $0.name == "scope" })?.value
+    #expect(decodedScope == scope)
+    #expect(queryItems.first(where: { $0.name == "action" }) == nil)
+  }
 }


### PR DESCRIPTION
## What changed

- persist the exact granted scope set on every OAuth session
- reject token responses with a missing scope or without the required `atproto` scope
- update persisted grants when refresh rotates tokens, preserving reduced user grants
- expose granted scopes per account through `ATProtoClient`
- keep pre-migration sessions decodable with an empty grant set

## Why

OAuth clients need to make authorization decisions from the scopes the server actually granted, not the scopes originally requested. Refresh responses may also reduce or otherwise change those grants.

## Validation

- `swift test` (84 XCTest tests, 195 Swift Testing tests, 29 load tests)
- new coverage for exact grants, missing scope, missing `atproto`, and legacy session decoding